### PR TITLE
Handle cases where the browser has already decompressed Pagefind files

### DIFF
--- a/pagefind/src/output/mod.rs
+++ b/pagefind/src/output/mod.rs
@@ -141,6 +141,7 @@ async fn write(
         Compress::GZ => {
             let mut gz = GzEncoder::new(Vec::new(), Compression::best());
             for chunk in contents {
+                gz.write_all(b"pagefind_dcd").unwrap();
                 gz.write_all(chunk).unwrap();
             }
             if let Ok(bytes) = gz.finish() {


### PR DESCRIPTION
Linked: #27 

Adds a magic word to the decompressed data of all Pagefind compressed files. Detecting the presence of this word can flag whether a server has added the headers required for a browser to decompress the files, meaning we should not run our own `gunzip` function.
