### PR TITLE
Custom glob configuration and URL overrides

### DIFF
--- a/docs/content/docs/config-options.md
+++ b/docs/content/docs/config-options.md
@@ -44,3 +44,9 @@ Note that filters and metadata outside of this selector will **not** be detected
 |-------------------------|--------------------------|-----------------|
 | `--root-selector <DIR>` | `PAGEFIND_ROOT_SELECTOR` | `root_selector` |
 
+### Glob
+Configures the glob used by Pagefind to discover HTML files. Defaults to `**/*.{html}`.
+
+| CLI Flag        | ENV Variable    | Config Key |
+|-----------------|-----------------|------------|
+| `--glob <GLOB>` | `PAGEFIND_GLOB` | `glob`     |

--- a/docs/content/docs/ui.md
+++ b/docs/content/docs/ui.md
@@ -48,6 +48,14 @@ Pagefind UI can be styled manually by omitting the `/_pagefind/pagefind-ui.css` 
 
 The classnames within Pagefind UI that begin with `pagefind-ui` should be targeted. These may change, so if you are styling them yourself make sure to test new releases of Pagefind with your stylesheet. Changes to classnames will be highlighted in the release notes, but will not be signalled by a major release.
 
+## Overriding the URL of a result
+
+The Pagefind UI will look for a value under the metadata key `url`, and use that for result links if present. This allows you to override the URL of a single page by tagging metadata on that page, for example:
+
+```html
+<link data-pagefind-meta="url[href]" rel="canonical" href="https://example.com/other-url">
+```
+
 ## PagefindUI options
 
 These options configure Pagefind UI itself. Any extra keys in this object will be passed on to [configure the Pagefind search API](/docs/search-config/).

--- a/pagefind/src/lib.rs
+++ b/pagefind/src/lib.rs
@@ -28,13 +28,20 @@ impl SearchState {
 
     pub async fn walk_for_files(&mut self) {
         println!("Walking source directory...");
-        let glob = Glob::new("**/*.{html}").unwrap();
-        self.files = glob
-            .walk(&self.options.source, usize::MAX)
-            .filter_map(Result::ok)
-            .map(WalkEntry::into_path)
-            .map(Fossicker::new)
-            .collect()
+        if let Ok(glob) = Glob::new(&self.options.glob) {
+            self.files = glob
+                .walk(&self.options.source, usize::MAX)
+                .filter_map(Result::ok)
+                .map(WalkEntry::into_path)
+                .map(Fossicker::new)
+                .collect()
+        } else {
+            eprintln!(
+                "Error: Provided glob \"{}\" did not parse as a valid glob.",
+                self.options.glob
+            );
+            std::process::exit(1);
+        }
     }
 
     pub async fn run(&mut self) {

--- a/pagefind/src/options.rs
+++ b/pagefind/src/options.rs
@@ -31,6 +31,14 @@ pub struct PagefindInboundConfig {
 
     #[clap(
         long,
+        help = "The file glob Pagefind uses to find HTML files. Defaults to \"**/*.{html}\""
+    )]
+    #[clap(required = false)]
+    #[serde(default = "defaults::default_glob")]
+    pub glob: String,
+
+    #[clap(
+        long,
         help = "Serve the source directory after creating the search index"
     )]
     #[clap(required = false)]
@@ -54,6 +62,9 @@ mod defaults {
     pub fn default_root_selector() -> String {
         "html".into()
     }
+    pub fn default_glob() -> String {
+        "**/*.{html}".into()
+    }
     pub fn default_false() -> bool {
         false
     }
@@ -66,6 +77,7 @@ pub struct SearchOptions {
     pub source: PathBuf,
     pub bundle_dir: PathBuf,
     pub root_selector: String,
+    pub glob: String,
     pub verbose: bool,
     pub version: &'static str,
 }
@@ -82,6 +94,7 @@ impl SearchOptions {
                 source: PathBuf::from(config.source),
                 bundle_dir: PathBuf::from(config.bundle_dir),
                 root_selector: config.root_selector,
+                glob: config.glob,
                 verbose: config.verbose,
                 version: env!("CARGO_PKG_VERSION"),
             })

--- a/pagefind/test.sh
+++ b/pagefind/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+cargo build --release
+TEST_BINARY=../target/release/pagefind npx humane

--- a/pagefind_ui/svelte/result.svelte
+++ b/pagefind_ui/svelte/result.svelte
@@ -1,6 +1,6 @@
 <script>
     export let result = { data: async () => {} };
-    const skipMeta = ["title", "image", "image_alt"];
+    const skipMeta = ["title", "image", "image_alt", "url"];
 
     let data;
     let meta = [];
@@ -31,8 +31,9 @@
         </div>
         <div class="pagefind-ui__result-inner">
             <p class="pagefind-ui__result-title">
-                <a class="pagefind-ui__result-link" href={data.url}
-                    >{data.meta?.title}</a
+                <a
+                    class="pagefind-ui__result-link"
+                    href={data.meta?.url || data.url}>{data.meta?.title}</a
                 >
             </p>
             <p class="pagefind-ui__result-excerpt">{@html data.excerpt}</p>


### PR DESCRIPTION
Linked: #26 

Adds a `glob` configuration key to override Pagefind's default HTML glob.

Also adds a feature where the Pagefind UI will prioritize `data.meta.url` over `data.url`, which allows for custom URLs by setting a `url` metadata key.