### PR TITLE
Fix many instances of HTML entity escaping in Pagefind UI

### DIFF
--- a/pagefind_ui/dev_files/_pagefind/pagefind.js
+++ b/pagefind_ui/dev_files/_pagefind/pagefind.js
@@ -57,7 +57,7 @@ const stubbed_results = [
             meta: {
                 title: `TERM the llama`,
                 image: "https://placekitten.com/900/600",
-                name: "Steve"
+                name: "Steve &ndash; nice person"
             },
             word_count: 100,
             excerpt: `Nullam id dolor id nibh ultricies TERM vehicula ut id elit.`
@@ -135,6 +135,7 @@ const stubbed_filters = (max) => {
             Red: num(max),
             Blue: num(max),
             Green: num(max),
+            "Amb&#39;er": num(max),
         },
         type: {
             Blog: num(max),

--- a/pagefind_ui/svelte/filters.svelte
+++ b/pagefind_ui/svelte/filters.svelte
@@ -10,13 +10,13 @@
             {#each Object.entries(available_filters) as [filter, values]}
                 <details class="pagefind-ui__filter-block">
                     <summary class="pagefind-ui__filter-name"
-                        >{filter.replace(/^(\w)/, (c) =>
+                        >{@html filter.replace(/^(\w)/, (c) =>
                             c.toLocaleUpperCase()
                         )}</summary
                     >
                     <fieldset class="pagefind-ui__filter-group">
                         <legend class="pagefind-ui__filter-group-label"
-                            >{filter}</legend
+                            >{@html filter}</legend
                         >
                         {#each Object.entries(values) as [value, count]}
                             <div
@@ -38,7 +38,7 @@
                                 <label
                                     class="pagefind-ui__filter-label"
                                     for="{filter}-{value}"
-                                    >{value} ({count})</label
+                                    >{@html value} ({count})</label
                                 >
                             </div>
                         {/each}

--- a/pagefind_ui/svelte/result.svelte
+++ b/pagefind_ui/svelte/result.svelte
@@ -32,7 +32,7 @@
         <div class="pagefind-ui__result-inner">
             <p class="pagefind-ui__result-title">
                 <a class="pagefind-ui__result-link" href={data.url}
-                    >{data.meta?.title}</a
+                    >{@html data.meta?.title}</a
                 >
             </p>
             <p class="pagefind-ui__result-excerpt">{@html data.excerpt}</p>
@@ -40,9 +40,9 @@
                 <ul class="pagefind-ui__result-tags">
                     {#each meta as [metaTitle, metaValue]}
                         <li class="pagefind-ui__result-tag">
-                            {metaTitle.replace(/^(\w)/, (c) =>
+                            {@html metaTitle.replace(/^(\w)/, (c) =>
                                 c.toLocaleUpperCase()
-                            )}: {metaValue}
+                            )}: {@html metaValue}
                         </li>
                     {/each}
                 </ul>


### PR DESCRIPTION
Linked: #24 

Fixes HTML entities in titles, filters, and metadata.