### PR TITLE
Improvements to the filter panel

### DIFF
--- a/docs/content/docs/ui.md
+++ b/docs/content/docs/ui.md
@@ -60,6 +60,17 @@ new PagefindUI({ element: "#search" });
 
 A selector for the HTML element to attach Pagefind UI to. This is the only required argument.
 
+### Show empty filters
+
+```javascript
+new PagefindUI({
+    element: "#search",
+    showEmptyFilters: true
+});
+```
+
+By default, Pagefind UI shows filters with no results alongside the count (0). Pass `false` to hide filters that have no remaining results.
+
 ### Reset styles
 
 ```javascript

--- a/pagefind_ui/svelte/filters.svelte
+++ b/pagefind_ui/svelte/filters.svelte
@@ -1,6 +1,21 @@
 <script>
     export let available_filters = null;
     export const selected_filters = {};
+
+    let initialized = false;
+    let default_open = false;
+
+    $: if (available_filters && !initialized) {
+        initialized = true;
+        let filters = Object.entries(available_filters);
+        if (filters.length === 1) {
+            let values = Object.entries(filters[0][1]);
+            if (values.length <= 6) {
+                // No need to hide a single filter group with only a few options
+                default_open = true;
+            }
+        }
+    }
 </script>
 
 {#if !available_filters || Object.entries(available_filters).length}
@@ -8,7 +23,7 @@
         <legend class="pagefind-ui__filter-panel-label">Filters</legend>
         {#if available_filters}
             {#each Object.entries(available_filters) as [filter, values]}
-                <details class="pagefind-ui__filter-block">
+                <details class="pagefind-ui__filter-block" open={default_open}>
                     <summary class="pagefind-ui__filter-name"
                         >{filter.replace(/^(\w)/, (c) =>
                             c.toLocaleUpperCase()

--- a/pagefind_ui/svelte/filters.svelte
+++ b/pagefind_ui/svelte/filters.svelte
@@ -1,5 +1,6 @@
 <script>
     export let available_filters = null;
+    export let show_empty_filters = true;
     export const selected_filters = {};
 
     let initialized = false;
@@ -34,28 +35,30 @@
                             >{filter}</legend
                         >
                         {#each Object.entries(values) as [value, count]}
-                            <div
-                                class="pagefind-ui__filter-value"
-                                class:pagefind-ui__filter-value--checked={selected_filters[
-                                    `${filter}:${value}`
-                                ]}
-                            >
-                                <input
-                                    class="pagefind-ui__filter-checkbox"
-                                    type="checkbox"
-                                    id="{filter}-{value}"
-                                    name={filter}
-                                    bind:checked={selected_filters[
+                            {#if show_empty_filters || count || selected_filters[`${filter}:${value}`]}
+                                <div
+                                    class="pagefind-ui__filter-value"
+                                    class:pagefind-ui__filter-value--checked={selected_filters[
                                         `${filter}:${value}`
                                     ]}
-                                    {value}
-                                />
-                                <label
-                                    class="pagefind-ui__filter-label"
-                                    for="{filter}-{value}"
-                                    >{value} ({count})</label
                                 >
-                            </div>
+                                    <input
+                                        class="pagefind-ui__filter-checkbox"
+                                        type="checkbox"
+                                        id="{filter}-{value}"
+                                        name={filter}
+                                        bind:checked={selected_filters[
+                                            `${filter}:${value}`
+                                        ]}
+                                        {value}
+                                    />
+                                    <label
+                                        class="pagefind-ui__filter-label"
+                                        for="{filter}-{value}"
+                                        >{value} ({count})</label
+                                    >
+                                </div>
+                            {/if}
                         {/each}
                     </fieldset>
                 </details>

--- a/pagefind_ui/svelte/ui.svelte
+++ b/pagefind_ui/svelte/ui.svelte
@@ -5,6 +5,7 @@
 
     export let base_path = "/_pagefind/";
     export let reset_styles = true;
+    export let show_empty_filters = true;
     export let pagefind_options = {};
 
     let val = "";
@@ -101,7 +102,11 @@
 
         <div class="pagefind-ui__drawer" class:pagefind-ui__hidden={!searched}>
             {#if initializing}
-                <Filters {available_filters} bind:selected_filters />
+                <Filters
+                    {show_empty_filters}
+                    {available_filters}
+                    bind:selected_filters
+                />
             {/if}
 
             {#if searched}

--- a/pagefind_ui/svelte/ui.svelte
+++ b/pagefind_ui/svelte/ui.svelte
@@ -56,9 +56,8 @@
 
     const search = async (term, raw_filters) => {
         const filters = parseSelectedFilters(raw_filters);
-        if (!term && !Object.keys(filters).length) {
+        if (!term) {
             searched = false;
-            available_filters = initial_filters;
             return;
         }
         search_term = term || "";
@@ -100,12 +99,12 @@
             placeholder="Search"
         />
 
-        <div class="pagefind-ui__drawer">
-            {#if searched}
-                {#if initializing}
-                    <Filters {available_filters} bind:selected_filters />
-                {/if}
+        <div class="pagefind-ui__drawer" class:pagefind-ui__hidden={!searched}>
+            {#if initializing}
+                <Filters {available_filters} bind:selected_filters />
+            {/if}
 
+            {#if searched}
                 <div class="pagefind-ui__results-area">
                     {#if loading}
                         {#if search_term}
@@ -210,6 +209,9 @@
         display: flex;
         flex-direction: row;
         flex-wrap: wrap;
+    }
+    .pagefind-ui__hidden {
+        display: none;
     }
     .pagefind-ui__results-area {
         min-width: min(calc(400px * var(--pagefind-ui-scale)), 100%);

--- a/pagefind_ui/ui.js
+++ b/pagefind_ui/ui.js
@@ -15,11 +15,13 @@ class PagefindUI {
         let selector = opts.element ?? "[data-pagefind-ui]";
         let bundlePath = opts.bundlePath ?? scriptBundlePath;
         let resetStyles = opts.resetStyles ?? true;
+        let showEmptyFilters = opts.showEmptyFilters ?? true;
 
         // Remove the UI-specific config before passing it along to the Pagefind backend
         delete opts["element"];
         delete opts["bundlePath"];
         delete opts["resetStyles"];
+        delete opts["showEmptyFilters"];
 
         const dom = document.querySelector(selector);
         if (dom) {
@@ -28,6 +30,7 @@ class PagefindUI {
                 props: {
                     base_path: bundlePath,
                     reset_styles: resetStyles,
+                    show_empty_filters: showEmptyFilters,
                     pagefind_options: opts,
                 }
             })


### PR DESCRIPTION
Linked: #23 

- Adds configuration to show/hide filters that have no results for the current search term
- Expands small filter groups by default
- Preserves filter selections if the search input is emptied
