### PR TITLE
Allow ignoring an element and its children from all processing

### DIFF
--- a/docs/content/docs/indexing.md
+++ b/docs/content/docs/indexing.md
@@ -44,7 +44,21 @@ If you have a component that you don't want to include in your search index, you
 </main>
 ```
 
-> Filters and Metadata will still be used if placed within a `data-pagefind-ignore` element.
+The `data-pagefind-ignore` attribute can optionally take a value of `index` or `all`. Omitting a value implies `index`, which will exclude the element and all children from the search index, but will still process filters and metadata within the element, and will still try to detect a default title or image found within this element.
+
+Specifying `all` will exclude the element and its children from all processing.
+
+```html
+<aside data-pagefind-ignore>
+    <h1>This might still be detected as the page title</h1>
+    <p data-pagefind-meta="a">This metadata will still appear in search results.</p>
+</aside>
+
+<aside data-pagefind-ignore="all">
+    <h1>This cannot be detected as the page title</h1>
+    <p data-pagefind-meta="b">This metadata will not be processed.</p>
+</aside>
+```
 
 ## Indexing attributes
 

--- a/pagefind/features/exclusions.feature
+++ b/pagefind/features/exclusions.feature
@@ -79,3 +79,42 @@ Feature: Exclusions
         Then There should be no logs
         Then The selector "[data-search-one]" should contain "Hello World, from Pagefind. Hooray!"
         Then The selector "[data-search-two]" should contain "0 result(s)"
+
+    Scenario: Tagged elements inside ignored elements can be ignored
+        Given I have a "public/index.html" file with the body:
+            """
+            <p data-search>Nothing</p>
+            """
+        Given I have a "public/cat/index.html" file with the body:
+            """
+            <p>Hello World, from Pagefind</p>
+            <div data-pagefind-ignore>
+                <p data-pagefind-meta="elided">Nested content</p>
+            </div>
+            <div data-pagefind-ignore="index">
+                <p data-pagefind-meta="index">Nested content</p>
+            </div>
+            <div data-pagefind-ignore="all">
+                <p data-pagefind-meta="all">Nested content</p>
+            </div>
+            """
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/_pagefind/pagefind.js");
+
+                let search = await pagefind.search("hello");
+                let searchdata = await search.results[0].data();
+                document.querySelector('[data-search]').innerText = [
+                    searchdata.meta?.elided || "None",
+                    searchdata.meta?.index || "None",
+                    searchdata.meta?.all || "None",
+                ].join(' — ');
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-search]" should contain "Nested content — Nested content — None"


### PR DESCRIPTION
Linked: #19 

Adds `data-pagefind-ignore="all"` as an attribute to further exclude filters and metadata present within an element.