### PR TITLE
Pagefind multilingual support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,13 +244,7 @@ jobs:
 
       - name: Build WASM
         working-directory: ./pagefind_web
-        run: |
-          wasm-pack build --release -t no-modules
-          mkdir -p ../pagefind/vendor
-          cp pkg/pagefind_web_bg.wasm ../pagefind/vendor/pagefind_web_bg.$GIT_VERSION.wasm
-          cp pkg/pagefind_web.js ../pagefind/vendor/pagefind_web.$GIT_VERSION.js
-          ls -lh ../pagefind/vendor/
-          pwd
+        run: ./local_build.sh
 
       - name: Build UI
         working-directory: ./pagefind_ui
@@ -258,19 +252,27 @@ jobs:
 
       - name: Test Web
         working-directory: ./pagefind_web
-        run: cargo test --release
+        run: cargo test --release --features extended
 
       - name: Build
         working-directory: ./pagefind
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --target ${{ matrix.target }} --features extended
 
       - name: Test Lib
         working-directory: ./pagefind
-        run: cargo test --release --target ${{ matrix.target }}
+        run: cargo test --release --target ${{ matrix.target }} --features extended
 
       - name: Test CLI
         working-directory: ./pagefind
         run: TEST_BINARY=../target/${{ matrix.target }}/release/pagefind humane
+
+      - name: Move extended binary aside
+        run: |
+          cp target/${{ matrix.target }}/release/pagefind target/${{ matrix.target }}/release/pagefind_extended
+
+      - name: Build Non-Extended
+        working-directory: ./pagefind
+        run: cargo build --release --target ${{ matrix.target }}
 
       - name: Package Artifacts
         run: |
@@ -288,30 +290,50 @@ jobs:
                   ;;
           esac
           cp target/${{ matrix.target }}/release/pagefind $stage/
+          cp target/${{ matrix.target }}/release/pagefind_extended $stage/
           cd $stage
           RELEASE_VERSION=${GITHUB_REF#refs/tags/}
+
           ASSET_NAME="pagefind-$RELEASE_VERSION-${{ matrix.target }}.tar.gz"
           ASSET_PATH="$src/$ASSET_NAME"
+
+          EXTENDED_ASSET_NAME="pagefind_extended-$RELEASE_VERSION-${{ matrix.target }}.tar.gz"
+          EXTENDED_ASSET_PATH="$src/$EXTENDED_ASSET_NAME"
+
           CHECKSUM_PATH="$ASSET_PATH.sha256"
+          EXTENDED_CHECKSUM_PATH="$EXTENDED_ASSET_PATH.sha256"
+
           tar czf $ASSET_PATH *
+          tar czf $EXTENDED_ASSET_PATH *
+
           cd $src
           case $RUNNER_OS in
               Windows)
                   sha256sum $ASSET_NAME > $CHECKSUM_PATH
+                  sha256sum $EXTENDED_ASSET_NAME > $EXTENDED_CHECKSUM_PATH
                   ;;
               Linux)
                   sha256sum $ASSET_NAME > $CHECKSUM_PATH
+                  sha256sum $EXTENDED_ASSET_NAME > $EXTENDED_CHECKSUM_PATH
                   ;;
               macOS)
                   shasum -a 256 $ASSET_NAME > $CHECKSUM_PATH
+                  shasum -a 256 $EXTENDED_ASSET_NAME > $EXTENDED_CHECKSUM_PATH
                   ;;
           esac
           if [ "$RUNNER_OS" == "Windows" ]; then
               ASSET_PATH=$(echo "$ASSET_PATH" | sed -e 's/^\///' -e 's/\//\\/g' -e 's/^./\0:/')
               CHECKSUM_PATH=$(echo "$CHECKSUM_PATH" | sed -e 's/^\///' -e 's/\//\\/g' -e 's/^./\0:/')
+
+              EXTENDED_ASSET_PATH=$(echo "$EXTENDED_ASSET_PATH" | sed -e 's/^\///' -e 's/\//\\/g' -e 's/^./\0:/')
+              EXTENDED_CHECKSUM_PATH=$(echo "$EXTENDED_CHECKSUM_PATH" | sed -e 's/^\///' -e 's/\//\\/g' -e 's/^./\0:/')
           fi
+
           echo "ASSET_PATH=$ASSET_PATH" >> $GITHUB_ENV
           echo "CHECKSUM_PATH=$CHECKSUM_PATH" >> $GITHUB_ENV
+
+          echo "EXTENDED_ASSET_PATH=$EXTENDED_ASSET_PATH" >> $GITHUB_ENV
+          echo "EXTENDED_CHECKSUM_PATH=$EXTENDED_CHECKSUM_PATH" >> $GITHUB_ENV
       - name: Upload build artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -319,9 +341,12 @@ jobs:
           path: |
             ${{ env.ASSET_PATH }}
             ${{ env.CHECKSUM_PATH }}
+            ${{ env.EXTENDED_ASSET_PATH }}
+            ${{ env.EXTENDED_CHECKSUM_PATH }}
       - name: Upload build artifacts
         uses: actions/upload-artifact@v3
         with:
           name: release-checksums
           path: |
             ${{ env.CHECKSUM_PATH }}
+            ${{ env.EXTENDED_CHECKSUM_PATH }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  HUMANE_VERSION: "0.3.4"
+  HUMANE_VERSION: "0.3.7"
 
 jobs:
   publish-crate:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,11 +86,11 @@ jobs:
 
       - name: Build Testing Binary
         working-directory: ./pagefind
-        run: cargo build --release
+        run: cargo build --release --features extended
 
       - name: Test Lib
         working-directory: ./pagefind
-        run: cargo test --release --lib
+        run: cargo test --release --lib --features extended
 
       - name: Test CLI
         working-directory: ./pagefind

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  HUMANE_VERSION: "0.3.4"
+  HUMANE_VERSION: "0.3.7"
 
 jobs:
   test:

--- a/docs/content/docs/config-options.md
+++ b/docs/content/docs/config-options.md
@@ -59,3 +59,10 @@ See [Multilingual search](/docs/multilingual/) for more details.
 | CLI Flag                  | ENV Variable              | Config Key       |
 |---------------------------|---------------------------|------------------|
 | `--force-language <LANG>` | `PAGEFIND_FORCE_LANGUAGE` | `force_language` |
+
+### Verbose
+Prints extra logging while indexing the site. Only affects the CLI, does not impact web-facing search.
+
+| CLI Flag    | ENV Variable       | Config Key |
+|-------------|--------------------|------------|
+| `--verbose` | `PAGEFIND_VERBOSE` | `verbose`  |

--- a/docs/content/docs/config-options.md
+++ b/docs/content/docs/config-options.md
@@ -50,3 +50,12 @@ Configures the glob used by Pagefind to discover HTML files. Defaults to `**/*.{
 | CLI Flag        | ENV Variable    | Config Key |
 |-----------------|-----------------|------------|
 | `--glob <GLOB>` | `PAGEFIND_GLOB` | `glob`     |
+
+### Force Language
+Ignores any detected languages and creates a single index for the entire site as the provided language. Expects an ISO 639-1 code, such as `en` or `pt`.
+
+See [Multilingual search](/docs/multilingual/) for more details.
+
+| CLI Flag                  | ENV Variable              | Config Key       |
+|---------------------------|---------------------------|------------------|
+| `--force-language <LANG>` | `PAGEFIND_FORCE_LANGUAGE` | `force_language` |

--- a/docs/content/docs/hosting.md
+++ b/docs/content/docs/hosting.md
@@ -3,7 +3,7 @@ date: 2022-06-01
 title: "Hosting Pagefind"
 nav_title: "Hosting Pagefind"
 nav_section: Notes
-weight: 80
+weight: 81
 ---
 
 Pagefind outputs a static bundle directory to your built site, and no hosting configuration is required.

--- a/docs/content/docs/multilingual.md
+++ b/docs/content/docs/multilingual.md
@@ -8,10 +8,54 @@ weight: 80
 
 Pagefind supports multilingual sites out of the box, with zero configuration. 
 
-When indexing, Pagefind will look for a [`lang` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang) on your `html` element. Indexing will then run independently for each detected language. When Pagefind initializes in the browser it will check the same `lang` attribute and load the appropriate index. 
+When indexing, Pagefind will look for a [`lang` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang) on your `html` element. Indexing will then run independently for each detected language. When Pagefind initializes in the browser it will check the same `lang` attribute and load the appropriate index.
 
-If you run Pagefind on a page tagged as `<html lang="pt-br">`, you will automatically search only the pages on the site with the same language. Pagefind will also adapt any stemming algorithms to the target language if supported.
+If you load Pagefind search on a page tagged as `<html lang="pt-br">`, you will automatically search only the pages on the site with the same language. Pagefind will also adapt any stemming algorithms to the target language if supported. This applies to both the Pagefind JS API and the Pagefind UI.
+
+The Pagefind UI itself is translated into a range of languages, and will adapt automatically to the page language if possible.
 
 ## Opting out of multilingual search
 
 Setting the [force language](/docs/config-options/#force-language) option when indexing will opt out of this feature and create one index for the site as a whole.
+
+## Language support
+
+Pagefind will work automatically for any language, explicit language support only improves the quality of search results and the Pagefind UI.
+
+If word stemming is unsupported, search results won't match across root words. If UI translations are unsupported, the Pagefind UI will be shown in English.
+
+> Feel free to [open an issue](https://github.com/CloudCannon/pagefind/issues/new) if there's a language you would like better support for, or [contribute a translation](https://github.com/CloudCannon/pagefind/tree/main/pagefind_ui/translations) for Pagefind UI in your language.
+
+| Language          | UI Translations | Word Stemming |
+|-------------------|-----------------|---------------|
+| Afrikaans — `af`  | ✅               | ❌             |
+| Arabic — `ar`     | ❌               | ✅             |
+| Armenian — `hy`   | ❌               | ✅             |
+| Basque — `eu`     | ❌               | ✅             |
+| Catalan — `ca`    | ❌               | ✅             |
+| Chinese — `zh`    | ✅               | ❌             |
+| Danish — `da`     | ❌               | ✅             |
+| Dutch — `nl`      | ❌               | ✅             |
+| English — `en`    | ✅               | ✅             |
+| Finnish — `fi`    | ❌               | ✅             |
+| French — `fr`     | ❌               | ✅             |
+| German — `de`     | ✅               | ✅             |
+| Greek — `el`      | ❌               | ✅             |
+| Hindi — `hi`      | ❌               | ✅             |
+| Hungarian — `hu`  | ❌               | ✅             |
+| Indonesian — `id` | ❌               | ✅             |
+| Irish — `ga`      | ❌               | ✅             |
+| Italian — `it`    | ❌               | ✅             |
+| Japanese — `ja`   | ✅               | ❌             |
+| Lithuanian — `lt` | ❌               | ✅             |
+| Nepali — `ne`     | ❌               | ✅             |
+| Norwegian — `no`  | ✅               | ✅             |
+| Portuguese — `pt` | ✅               | ✅             |
+| Romanian — `ro`   | ❌               | ✅             |
+| Russian — `ru`    | ✅               | ✅             |
+| Serbian — `sr`    | ❌               | ✅             |
+| Spanish — `es`    | ❌               | ✅             |
+| Swedish — `sv`    | ❌               | ✅             |
+| Tamil — `ta`      | ❌               | ✅             |
+| Turkish — `tr`    | ❌               | ✅             |
+| Yiddish — `yi`    | ❌               | ✅             |

--- a/docs/content/docs/multilingual.md
+++ b/docs/content/docs/multilingual.md
@@ -26,6 +26,8 @@ If word stemming is unsupported, search results won't match across root words. I
 
 > Feel free to [open an issue](https://github.com/CloudCannon/pagefind/issues/new) if there's a language you would like better support for, or [contribute a translation](https://github.com/CloudCannon/pagefind/tree/main/pagefind_ui/translations) for Pagefind UI in your language.
 
+> Pagefind does not yet support segmenting words for languages without whitespace between words. These languages will only index well if whitespace exists between words, or each individual word is wrapped in an element such as a `<span>`.
+
 | Language          | UI Translations | Word Stemming |
 |-------------------|-----------------|---------------|
 | Afrikaans — `af`  | ✅               | ❌             |

--- a/docs/content/docs/multilingual.md
+++ b/docs/content/docs/multilingual.md
@@ -1,0 +1,17 @@
+---
+date: 2022-06-01
+title: "Multilingual search"
+nav_title: "Multilingual search"
+nav_section: Indexing
+weight: 80
+---
+
+Pagefind supports multilingual sites out of the box, with zero configuration. 
+
+When indexing, Pagefind will look for a [`lang` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang) on your `html` element. Indexing will then run independently for each detected language. When Pagefind initializes in the browser it will check the same `lang` attribute and load the appropriate index. 
+
+If you run Pagefind on a page tagged as `<html lang="pt-br">`, you will automatically search only the pages on the site with the same language. Pagefind will also adapt any stemming algorithms to the target language if supported.
+
+## Opting out of multilingual search
+
+Setting the [force language](/docs/config-options/#force-language) option when indexing will opt out of this feature and create one index for the site as a whole.

--- a/pagefind/Cargo.toml
+++ b/pagefind/Cargo.toml
@@ -49,6 +49,7 @@ pagefind_stem = { version = "0.1.0", features = [
     "yiddish",
 ] }
 stop-words = "0.6.2"
+charabia = { version = "0.5.1", optional = true }
 hashbrown = { version = "0.12.0", features = ["serde"] }
 regex = "1.1"
 minicbor = { version = "0.15.0", features = ["derive"] }
@@ -71,3 +72,7 @@ twelf = { version = "0.5", default-features = false, features = [
 portpicker = "0.1"
 actix-web = "4"
 actix-files = "0.6"
+
+[features]
+
+extended = ["dep:charabia"]

--- a/pagefind/Cargo.toml
+++ b/pagefind/Cargo.toml
@@ -17,7 +17,36 @@ tokio = { version = "1", features = [
     "time",
     "macros",
 ] }
-pagefind_stem = { version = "0.1.0", features = ["english"] }
+pagefind_stem = { version = "0.1.0", features = [
+    "arabic",
+    "armenian",
+    "basque",
+    "catalan",
+    "danish",
+    "dutch",
+    "english",
+    "finnish",
+    "french",
+    "german",
+    "greek",
+    "hindi",
+    "hungarian",
+    "indonesian",
+    "irish",
+    "italian",
+    "lithuanian",
+    "nepali",
+    "norwegian",
+    "portuguese",
+    "romanian",
+    "russian",
+    "serbian",
+    "spanish",
+    "swedish",
+    "tamil",
+    "turkish",
+    "yiddish",
+] }
 stop-words = "0.6.2"
 hashbrown = { version = "0.12.0", features = ["serde"] }
 regex = "1.1"

--- a/pagefind/Cargo.toml
+++ b/pagefind/Cargo.toml
@@ -30,6 +30,7 @@ sha-1 = "0.10"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 lazy_static = "1.4.0"
+include_dir = "0.7.2"
 twelf = { version = "0.5", default-features = false, features = [
     "env",
     "clap",

--- a/pagefind/Cargo.toml
+++ b/pagefind/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "3.2.6", features = ["derive"] }
+console = "0.15.1"
 wax = "0.4.0"
 futures = "0.3"
 tokio = { version = "1", features = [

--- a/pagefind/features/metadata.feature
+++ b/pagefind/features/metadata.feature
@@ -2,10 +2,15 @@ Feature: Metadata
     Background:
         Given I have the environment variables:
             | PAGEFIND_SOURCE | public |
-        Given I have a "public/index.html" file with the body:
+        Given I have a "public/index.html" file with the content:
             """
-            <p data-result>Nothing</p>
-            <p data-result-two>Nothing</p>
+            <html>
+            <head></head>
+            <body>
+                <p data-result>Nothing</p>
+                <p data-result-two>Nothing</p>
+            </body>
+            </html>
             """
         # Covering all filter and metadata syntaxes
         Given I have a "public/cat/index.html" file with the content:

--- a/pagefind/features/multilingual.feature
+++ b/pagefind/features/multilingual.feature
@@ -79,8 +79,8 @@ Feature: Multilingual
         Then I should see "Running Pagefind" in stdout
         Then I should see the file "public/_pagefind/pagefind.js"
         Then I should see the file "public/_pagefind/wasm.unknown.pagefind"
-        Then I should see the file "public/_pagefind/wasm.pt.pagefind"
-        Then I should see "pt" in "public/_pagefind/pagefind-entry.json"
+        Then I should see the file "public/_pagefind/wasm.pt-br.pagefind"
+        Then I should see "pt-br" in "public/_pagefind/pagefind-entry.json"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
@@ -126,8 +126,10 @@ Feature: Multilingual
         Then I should see "Running Pagefind" in stdout
         Then I should see the file "public/_pagefind/pagefind.js"
         Then I should see the file "public/_pagefind/wasm.unknown.pagefind"
-        Then I should see the file "public/_pagefind/wasm.pt.pagefind"
-        Then I should see "pt" in "public/_pagefind/pagefind-entry.json"
+        Then I should see the file "public/_pagefind/wasm.pt-pt.pagefind"
+        Then I should see the file "public/_pagefind/wasm.pt-br.pagefind"
+        Then I should see "pt-pt" in "public/_pagefind/pagefind-entry.json"
+        Then I should see "pt-br" in "public/_pagefind/pagefind-entry.json"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
@@ -143,7 +145,6 @@ Feature: Multilingual
             """
         Then There should be no logs
         Then The selector "[data-result]" should contain "1 — /pt-br/"
-
 
     Scenario: Pagefind can be configured to lump all languages together
         Given I have a "public/index.html" file with the content:
@@ -164,7 +165,7 @@ Feature: Multilingual
         Then I should see the file "public/_pagefind/pagefind.js"
         Then I should see the file "public/_pagefind/wasm.unknown.pagefind"
         Then I should see the file "public/_pagefind/wasm.en.pagefind"
-        Then I should not see the file "public/_pagefind/wasm.pt.pagefind"
+        Then I should not see the file "public/_pagefind/wasm.pt-br.pagefind"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:

--- a/pagefind/features/multilingual.feature
+++ b/pagefind/features/multilingual.feature
@@ -1,0 +1,98 @@
+Feature: Multilingual
+    Background:
+        Given I have the environment variables:
+            | PAGEFIND_SOURCE | public |
+        Given I have a "public/en/index.html" file with the content:
+            """
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <title>Document</title>
+                </head>
+                <body>
+                    <p>I am some English documentation</p>
+                </body>
+            </html>
+            """
+        Given I have a "public/pt-br/index.html" file with the content:
+            """
+            <!DOCTYPE html>
+            <html lang="pt-br">
+                <head>
+                    <title>Document</title>
+                </head>
+                <body>
+                    <p>I am a Portugese document (trust me — quilométricas — see?)</p>
+                </body>
+            </html>
+            """
+
+    Scenario: Pagefind searches for English with English stemming
+        Given I have a "public/index.html" file with the content:
+            """
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <title>Document</title>
+                </head>
+                <body>
+                    <p data-result>Nothing</p>
+                </body>
+            </html>
+            """
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/_pagefind/wasm.unknown.pagefind"
+        Then I should see the file "public/_pagefind/wasm.en.pagefind"
+        Then I should see "en" in "public/_pagefind/pagefind-entry.json"
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/_pagefind/pagefind.js");
+
+                let search = await pagefind.search("documenting");
+
+                let data = search.results[0] ? await search.results[0].data() : "None";
+                document.querySelector('[data-result]').innerText = `${search.results.length} — ${data.url}`;
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-result]" should contain "1 — /en/"
+
+    Scenario: Pagefind searches for Portugese with Portugese stemming
+        Given I have a "public/index.html" file with the content:
+            """
+            <!DOCTYPE html>
+            <html lang="pt-br">
+                <head>
+                    <title>Document</title>
+                </head>
+                <body>
+                    <p data-result>Nothing</p>
+                </body>
+            </html>
+            """
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/_pagefind/wasm.unknown.pagefind"
+        Then I should see the file "public/_pagefind/wasm.pt.pagefind"
+        Then I should see "pt" in "public/_pagefind/pagefind-entry.json"
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/_pagefind/pagefind.js");
+
+                let search = await pagefind.search("quilométricos");
+
+                let data = search.results[0] ? await search.results[0].data() : "None";
+                document.querySelector('[data-result]').innerText = `${search.results.length} — ${data.url}`;
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-result]" should contain "1 — /pt-br/"

--- a/pagefind/src/fossick/mod.rs
+++ b/pagefind/src/fossick/mod.rs
@@ -141,7 +141,7 @@ fn build_url(page_url: &Path, options: &SearchOptions) -> String {
 
 // TODO: These language codes are duplicated with pagefind_web's Cargo.toml
 fn get_stemmer(lang: &str) -> Option<Stemmer> {
-    match lang {
+    match lang.split('-').next().unwrap() {
         "ar" => Some(Stemmer::create(Algorithm::Arabic)),
         "hy" => Some(Stemmer::create(Algorithm::Armenian)),
         "eu" => Some(Stemmer::create(Algorithm::Basque)),

--- a/pagefind/src/fossick/mod.rs
+++ b/pagefind/src/fossick/mod.rs
@@ -60,7 +60,12 @@ impl Fossicker {
             }
         }
 
-        self.data = Some(rewriter.wrap());
+        let mut data = rewriter.wrap();
+        if let Some(forced_language) = &options.force_language {
+            data.language = forced_language.clone();
+        }
+
+        self.data = Some(data);
 
         Ok(())
     }

--- a/pagefind/src/fossick/mod.rs
+++ b/pagefind/src/fossick/mod.rs
@@ -27,6 +27,7 @@ pub struct FossickedData {
     pub fragment: PageFragment,
     pub word_data: HashMap<String, Vec<u32>>,
     pub has_custom_body: bool,
+    pub language: Option<String>,
 }
 
 #[derive(Debug)]
@@ -102,25 +103,27 @@ impl Fossicker {
         map
     }
 
-    pub async fn fossick(&mut self, options: &SearchOptions) -> Result<FossickedData, ()> {
+    pub async fn fossick(mut self, options: &SearchOptions) -> Result<FossickedData, ()> {
         while self.read_file(options).await.is_err() {
             sleep(Duration::from_millis(1)).await;
         }
 
         let word_data = self.retrieve_words_from_digest();
 
-        let data = self.data.as_ref().unwrap();
+        let data = self.data.unwrap();
+        let url = build_url(&self.file_path, options);
 
         Ok(FossickedData {
-            file_path: self.file_path.clone(),
+            file_path: self.file_path,
             has_custom_body: data.has_custom_body,
+            language: data.language,
             fragment: PageFragment {
                 page_number: 0,
                 data: PageFragmentData {
-                    url: build_url(&self.file_path, options),
-                    content: data.digest.clone(),
-                    filters: data.filters.clone(),
-                    meta: data.meta.clone(),
+                    url,
+                    content: data.digest,
+                    filters: data.filters,
+                    meta: data.meta,
                     word_count: word_data.len(),
                 },
             },

--- a/pagefind/src/fossick/mod.rs
+++ b/pagefind/src/fossick/mod.rs
@@ -27,6 +27,7 @@ pub struct FossickedData {
     pub fragment: PageFragment,
     pub word_data: HashMap<String, Vec<u32>>,
     pub has_custom_body: bool,
+    pub has_html_element: bool,
     pub language: String,
 }
 
@@ -110,6 +111,7 @@ impl Fossicker {
         Ok(FossickedData {
             file_path: self.file_path,
             has_custom_body: data.has_custom_body,
+            has_html_element: data.has_html_element,
             language: data.language,
             fragment: PageFragment {
                 page_number: 0,

--- a/pagefind/src/fossick/mod.rs
+++ b/pagefind/src/fossick/mod.rs
@@ -67,30 +67,19 @@ impl Fossicker {
 
     fn retrieve_words_from_digest(&mut self) -> HashMap<String, Vec<u32>> {
         let mut map: HashMap<String, Vec<u32>> = HashMap::new();
-        let en_stemmer = Stemmer::create(Algorithm::English); // TODO: i18n
+        let data = self.data.as_ref().unwrap();
+        let stemmer = get_stemmer(&data.language);
 
-        // TODO: Reconsider stopwords. Removing them for now as they seem to remove too much,
-        // let mut words_to_remove = stop_words::get(stop_words::LANGUAGE::English);
-        // words_to_remove.retain(|w| w.len() < 5);
-
-        // TODO: Read newlines and jump the word_index up some amount,
+        // TODO: Consider reading newlines and jump the word_index up some amount,
         // so that separate bodies of text don't return exact string
-        // matches across the boundaries.
+        // matches across the boundaries. Or otherwise use some marker byte for the boundary.
 
-        for (word_index, word) in self
-            .data
-            .as_ref()
-            .unwrap()
-            .digest
-            .to_lowercase()
-            .split_whitespace()
-            .enumerate()
-        {
+        for (word_index, word) in data.digest.to_lowercase().split_whitespace().enumerate() {
             let mut word = SPECIAL_CHARS.replace_all(word, "").into_owned();
-            word = en_stemmer.stem(&word).into_owned();
-            // if words_to_remove.contains(&word) {
-            //     continue; // Removing stopwords for now...
-            // }
+            if let Some(stemmer) = &stemmer {
+                word = stemmer.stem(&word).into_owned();
+            }
+
             if !word.is_empty() {
                 if let Some(repeat) = map.get_mut(&word) {
                     repeat.push(word_index.try_into().unwrap());
@@ -141,6 +130,41 @@ fn build_url(page_url: &Path, options: &SearchOptions) -> String {
         "/{}",
         url.to_str().unwrap().to_owned().replace("index.html", "")
     )
+}
+
+// TODO: These language codes are duplicated with pagefind_web's Cargo.toml
+fn get_stemmer(lang: &str) -> Option<Stemmer> {
+    match lang {
+        "ar" => Some(Stemmer::create(Algorithm::Arabic)),
+        "hy" => Some(Stemmer::create(Algorithm::Armenian)),
+        "eu" => Some(Stemmer::create(Algorithm::Basque)),
+        "ca" => Some(Stemmer::create(Algorithm::Catalan)),
+        "da" => Some(Stemmer::create(Algorithm::Danish)),
+        "nl" => Some(Stemmer::create(Algorithm::Dutch)),
+        "en" => Some(Stemmer::create(Algorithm::English)),
+        "fi" => Some(Stemmer::create(Algorithm::Finnish)),
+        "fr" => Some(Stemmer::create(Algorithm::French)),
+        "de" => Some(Stemmer::create(Algorithm::German)),
+        "el" => Some(Stemmer::create(Algorithm::Greek)),
+        "hi" => Some(Stemmer::create(Algorithm::Hindi)),
+        "hu" => Some(Stemmer::create(Algorithm::Hungarian)),
+        "id" => Some(Stemmer::create(Algorithm::Indonesian)),
+        "ga" => Some(Stemmer::create(Algorithm::Irish)),
+        "it" => Some(Stemmer::create(Algorithm::Italian)),
+        "lt" => Some(Stemmer::create(Algorithm::Lithuanian)),
+        "ne" => Some(Stemmer::create(Algorithm::Nepali)),
+        "no" => Some(Stemmer::create(Algorithm::Norwegian)),
+        "pt" => Some(Stemmer::create(Algorithm::Portuguese)),
+        "ro" => Some(Stemmer::create(Algorithm::Romanian)),
+        "ru" => Some(Stemmer::create(Algorithm::Russian)),
+        "sr" => Some(Stemmer::create(Algorithm::Serbian)),
+        "es" => Some(Stemmer::create(Algorithm::Spanish)),
+        "sv" => Some(Stemmer::create(Algorithm::Swedish)),
+        "ta" => Some(Stemmer::create(Algorithm::Tamil)),
+        "tr" => Some(Stemmer::create(Algorithm::Turkish)),
+        "yi" => Some(Stemmer::create(Algorithm::Yiddish)),
+        _ => None,
+    }
 }
 
 #[cfg(test)]

--- a/pagefind/src/fossick/mod.rs
+++ b/pagefind/src/fossick/mod.rs
@@ -27,7 +27,7 @@ pub struct FossickedData {
     pub fragment: PageFragment,
     pub word_data: HashMap<String, Vec<u32>>,
     pub has_custom_body: bool,
-    pub language: Option<String>,
+    pub language: String,
 }
 
 #[derive(Debug)]

--- a/pagefind/src/fossick/parser.rs
+++ b/pagefind/src/fossick/parser.rs
@@ -95,7 +95,7 @@ pub struct DomParserResult {
     pub filters: HashMap<String, Vec<String>>,
     pub meta: HashMap<String, String>,
     pub has_custom_body: bool,
-    pub language: Option<String>,
+    pub language: String,
 }
 
 // Some shorthand to clean up our use of Rc<RefCell<*>> in the lol_html macros
@@ -120,7 +120,7 @@ impl<'a> DomParser<'a> {
                     enclose! { (data) element!("html", move |el| {
                         if let Some(lang) = el.get_attribute("lang") {
                             let mut data = data.borrow_mut();
-                            data.language = Some(lang);
+                            data.language = Some(lang.to_lowercase().split('-').next().unwrap().to_string());
                         }
                         Ok(())
                     })},
@@ -442,7 +442,10 @@ impl<'a> DomParser<'a> {
             filters: data.filters,
             meta: data.default_meta,
             has_custom_body: node.status == NodeStatus::ParentOfBody,
-            language: data.language,
+            language: data
+                .language
+                .filter(|lang| !lang.is_empty())
+                .unwrap_or_else(|| "unknown".into()),
         }
     }
 }

--- a/pagefind/src/fossick/parser.rs
+++ b/pagefind/src/fossick/parser.rs
@@ -437,6 +437,7 @@ impl<'a> DomParser<'a> {
         data.default_meta.extend(data.meta);
 
         let node = node.borrow();
+
         DomParserResult {
             digest: normalize_content(&node.current_value),
             filters: data.filters,

--- a/pagefind/src/fossick/parser.rs
+++ b/pagefind/src/fossick/parser.rs
@@ -123,7 +123,7 @@ impl<'a> DomParser<'a> {
                         let mut data = data.borrow_mut();
                         data.has_html_element = true;
                         if let Some(lang) = el.get_attribute("lang") {
-                            data.language = Some(lang.to_lowercase().split('-').next().unwrap().to_string());
+                            data.language = Some(lang.to_lowercase());
                         }
                         Ok(())
                     })},
@@ -489,7 +489,7 @@ fn parse_attr_string(input: String, el: &Element) -> Vec<String> {
 
 impl DomParsingNode {
     fn get_attribute_pair(&self, input: &str) -> Option<(String, String)> {
-        match input.split_once(":") {
+        match input.split_once(':') {
             Some((filter, value)) => Some((filter.to_owned(), value.to_owned())),
             None => {
                 if self.current_value.is_empty() {

--- a/pagefind/src/fossick/parser.rs
+++ b/pagefind/src/fossick/parser.rs
@@ -51,6 +51,7 @@ struct DomParserData {
     filters: HashMap<String, Vec<String>>,
     meta: HashMap<String, String>,
     default_meta: HashMap<String, String>,
+    language: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -94,6 +95,7 @@ pub struct DomParserResult {
     pub filters: HashMap<String, Vec<String>>,
     pub meta: HashMap<String, String>,
     pub has_custom_body: bool,
+    pub language: Option<String>,
 }
 
 // Some shorthand to clean up our use of Rc<RefCell<*>> in the lol_html macros
@@ -115,6 +117,13 @@ impl<'a> DomParser<'a> {
         let rewriter = HtmlRewriter::new(
             Settings {
                 element_content_handlers: vec![
+                    enclose! { (data) element!("html", move |el| {
+                        if let Some(lang) = el.get_attribute("lang") {
+                            let mut data = data.borrow_mut();
+                            data.language = Some(lang);
+                        }
+                        Ok(())
+                    })},
                     enclose! { (data) element!(root, move |el| {
                         let explicit_ignore_flag = el.get_attribute("data-pagefind-ignore").map(|attr| {
                             match attr.to_ascii_lowercase().as_str() {
@@ -433,6 +442,7 @@ impl<'a> DomParser<'a> {
             filters: data.filters,
             meta: data.default_meta,
             has_custom_body: node.status == NodeStatus::ParentOfBody,
+            language: data.language,
         }
     }
 }

--- a/pagefind/src/fossick/parser.rs
+++ b/pagefind/src/fossick/parser.rs
@@ -52,6 +52,7 @@ struct DomParserData {
     meta: HashMap<String, String>,
     default_meta: HashMap<String, String>,
     language: Option<String>,
+    has_html_element: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -95,6 +96,7 @@ pub struct DomParserResult {
     pub filters: HashMap<String, Vec<String>>,
     pub meta: HashMap<String, String>,
     pub has_custom_body: bool,
+    pub has_html_element: bool,
     pub language: String,
 }
 
@@ -110,7 +112,7 @@ macro_rules! enclose {
 }
 
 impl<'a> DomParser<'a> {
-    pub fn new(options: &SearchOptions) -> Self {
+    pub fn new(options: &'a SearchOptions) -> Self {
         let data = Rc::new(RefCell::new(DomParserData::default()));
         let root = format!("{}, {} *", options.root_selector, options.root_selector);
 
@@ -118,8 +120,9 @@ impl<'a> DomParser<'a> {
             Settings {
                 element_content_handlers: vec![
                     enclose! { (data) element!("html", move |el| {
+                        let mut data = data.borrow_mut();
+                        data.has_html_element = true;
                         if let Some(lang) = el.get_attribute("lang") {
-                            let mut data = data.borrow_mut();
                             data.language = Some(lang.to_lowercase().split('-').next().unwrap().to_string());
                         }
                         Ok(())
@@ -130,7 +133,7 @@ impl<'a> DomParser<'a> {
                                 "" | "index" => NodeStatus::Ignored,
                                 "all" => NodeStatus::Excluded,
                                 _ => {
-                                    eprintln!("data-pagefind-ignore value of \"{}\" is not valid. Expected no value, or one of: [index, all]. Assuming 'all' and excluding this element entirely.", attr);
+                                    options.logger.warn(format!("data-pagefind-ignore value of \"{}\" is not valid. Expected no value, or one of: [index, all]. Assuming 'all' and excluding this element entirely.", attr));
                                     NodeStatus::Excluded
                                 }
                             }
@@ -443,6 +446,7 @@ impl<'a> DomParser<'a> {
             filters: data.filters,
             meta: data.default_meta,
             has_custom_body: node.status == NodeStatus::ParentOfBody,
+            has_html_element: data.has_html_element,
             language: data
                 .language
                 .filter(|lang| !lang.is_empty())

--- a/pagefind/src/index/mod.rs
+++ b/pagefind/src/index/mod.rs
@@ -165,12 +165,13 @@ where
     }
 
     if TryInto::<u32>::try_into(meta.pages.len()).is_err() {
-        panic!("Too many documents to index");
+        options.logger.error(format!(
+            "Language {} has too many documents to index, must be < {}",
+            language,
+            u32::MAX
+        ));
+        std::process::exit(1);
     }
-
-    println!("Indexed {:?} pages", meta.pages.len());
-    println!("Indexed {:?} words", word_map.len());
-    println!("Indexed {:?} filters", meta.filters.len());
 
     // TODO: Parameterize these chunk sizes via options
     let chunks = chunk_index(word_map, 20000);
@@ -199,8 +200,6 @@ where
         word_indexes.insert(short_hash.to_string(), word_index);
         meta.index_chunks[i].hash = short_hash.into();
     }
-
-    println!("Created {:?} index chunks", word_indexes.len());
 
     let mut meta_index: Vec<u8> = Vec::new();
     let _ = minicbor::encode::<MetaIndex, &mut Vec<u8>>(meta, meta_index.as_mut());

--- a/pagefind/src/index/mod.rs
+++ b/pagefind/src/index/mod.rs
@@ -96,7 +96,7 @@ where
             encoded_data,
         };
 
-        let mut short_hash = &encoded_page.full_hash[0..=9];
+        let mut short_hash = &encoded_page.full_hash[0..=(language.len() + 7)];
 
         // If we hit a collision, extend one until we stop colliding
         // TODO: There are some collision issues here.
@@ -145,7 +145,7 @@ where
             filter_index.as_mut(),
         );
         let hash = format!("{}_{}", language, full_hash(&filter_index));
-        let mut short_hash = &hash[0..=9];
+        let mut short_hash = &hash[0..=(language.len() + 7)];
 
         // If we hit a collision, extend one hash until we stop colliding
         // TODO: DRY
@@ -186,7 +186,7 @@ where
         );
 
         let hash = format!("{}_{}", language, full_hash(&word_index));
-        let mut short_hash = &hash[0..=9];
+        let mut short_hash = &hash[0..=(language.len() + 7)];
 
         // If we hit a collision, extend one hash until we stop colliding
         while word_indexes.contains_key(short_hash) {
@@ -204,7 +204,11 @@ where
     let mut meta_index: Vec<u8> = Vec::new();
     let _ = minicbor::encode::<MetaIndex, &mut Vec<u8>>(meta, meta_index.as_mut());
 
-    let meta_hash = format!("{}_{}", language, &full_hash(&meta_index)[0..=6]);
+    let meta_hash = format!(
+        "{}_{}",
+        language,
+        &full_hash(&meta_index)[0..=(language.len() + 7)]
+    );
 
     PagefindIndexes {
         word_indexes,

--- a/pagefind/src/index/mod.rs
+++ b/pagefind/src/index/mod.rs
@@ -17,6 +17,7 @@ pub struct PagefindIndexes {
     pub meta_index: (String, Vec<u8>),
     pub fragments: Vec<(String, String)>,
     pub language: String,
+    pub word_count: usize,
 }
 
 #[derive(Clone)]
@@ -174,6 +175,7 @@ where
     }
 
     // TODO: Parameterize these chunk sizes via options
+    let word_count = word_map.len();
     let chunks = chunk_index(word_map, 20000);
     meta.index_chunks = chunk_meta(&chunks);
 
@@ -219,6 +221,7 @@ where
             .map(|(_, (hash, frag))| (hash, frag.encoded_data))
             .collect(),
         language,
+        word_count,
     }
 }
 

--- a/pagefind/src/lib.rs
+++ b/pagefind/src/lib.rs
@@ -48,7 +48,13 @@ impl SearchState {
 
     pub async fn run(&mut self) {
         let log = &self.options.logger;
+        #[cfg(not(feature = "extended"))]
         log.status(&format!("Running Pagefind v{}", self.options.version));
+        #[cfg(feature = "extended")]
+        log.status(&format!(
+            "Running Pagefind v{} (Extended)",
+            self.options.version
+        ));
         log.v_info("Running in verbose mode");
 
         log.info(format!(
@@ -201,6 +207,20 @@ impl SearchState {
                 index.filter_indexes.len(),
                 plural!(index.filter_indexes.len())
             ));
+
+            #[cfg(not(feature = "extended"))]
+            match index.language.split('-').next() {
+                Some("zh") => log.warn("⚠ Indexing Chinese in non-extended mode. \n\
+                                        In this mode, Pagefind will not segment words that are not whitespace separated. \n\
+                                        Running the extended Pagefind binary will include this segmentation. \n\
+                                        Either download the pagefind_extended binary, or run npx pagefind-extended."),
+                Some("ja") => log.warn("⚠ Indexing Japanese in non-extended mode. \n\
+                                        In this mode, Pagefind will not segment words that are not whitespace separated. \n\
+                                        Running the extended Pagefind binary will include this segmentation. \n\
+                                        Either download the pagefind_extended binary, or run npx pagefind-extended."),
+                _ => {}
+            };
+
             stats.0 += index.fragments.len();
             stats.1 += index.word_count;
             stats.2 += index.filter_indexes.len();

--- a/pagefind/src/lib.rs
+++ b/pagefind/src/lib.rs
@@ -196,13 +196,13 @@ impl SearchState {
                 index.language,
                 index.fragments.len(),
                 plural!(index.fragments.len()),
-                index.word_indexes.len(),
-                plural!(index.word_indexes.len()),
+                index.word_count,
+                plural!(index.word_count),
                 index.filter_indexes.len(),
                 plural!(index.filter_indexes.len())
             ));
             stats.0 += index.fragments.len();
-            stats.1 += index.word_indexes.len();
+            stats.1 += index.word_count;
             stats.2 += index.filter_indexes.len();
             stats
         });

--- a/pagefind/src/lib.rs
+++ b/pagefind/src/lib.rs
@@ -194,11 +194,7 @@ impl SearchState {
 
         let index_entries: Vec<_> = indexes
             .into_iter()
-            .map(|indexes| async {
-                let index_meta = (indexes.language.clone(), indexes.meta_index.0.clone());
-                indexes.write_files(&self.options).await;
-                index_meta
-            })
+            .map(|indexes| async { indexes.write_files(&self.options).await })
             .collect();
         let index_entries = join_all(index_entries).await;
 

--- a/pagefind/src/logging.rs
+++ b/pagefind/src/logging.rs
@@ -1,0 +1,126 @@
+use std::fmt::Debug;
+
+use console::{Style, Term};
+use lazy_static::lazy_static;
+
+#[derive(Debug)]
+pub enum LogLevel {
+    Standard,
+    Verbose,
+}
+
+pub enum LogStyle {
+    Info,
+    Status,
+    Warning,
+    Error,
+    Success,
+}
+
+pub struct Logger {
+    log_level: LogLevel,
+    out: Term,
+    err: Term,
+}
+
+macro_rules! plural {
+    ($len:expr) => {
+        match $len {
+            1 => "",
+            _ => "s",
+        }
+    };
+}
+
+impl Debug for Logger {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Logger")
+            .field("log_level", &self.log_level)
+            .finish()
+    }
+}
+
+lazy_static! {
+    static ref STATUS: Style = Style::new().cyan().bold();
+    static ref WARN: Style = Style::new().yellow();
+    static ref ERROR: Style = Style::new().red();
+    static ref SUCCESS: Style = Style::new().green();
+}
+
+impl Logger {
+    pub fn new(log_level: LogLevel) -> Self {
+        Self {
+            log_level,
+            out: Term::stdout(),
+            err: Term::stderr(),
+        }
+    }
+
+    pub fn info<S: AsRef<str>>(&self, msg: S) {
+        self.log(msg, LogLevel::Standard, LogStyle::Info);
+    }
+
+    pub fn v_info<S: AsRef<str>>(&self, msg: S) {
+        self.log(msg, LogLevel::Verbose, LogStyle::Info);
+    }
+
+    pub fn status<S: AsRef<str>>(&self, msg: S) {
+        self.log(msg, LogLevel::Standard, LogStyle::Status);
+    }
+
+    pub fn v_status<S: AsRef<str>>(&self, msg: S) {
+        self.log(msg, LogLevel::Verbose, LogStyle::Status);
+    }
+
+    pub fn warn<S: AsRef<str>>(&self, msg: S) {
+        self.log(msg, LogLevel::Standard, LogStyle::Warning);
+    }
+
+    pub fn v_warn<S: AsRef<str>>(&self, msg: S) {
+        self.log(msg, LogLevel::Verbose, LogStyle::Warning);
+    }
+
+    pub fn error<S: AsRef<str>>(&self, msg: S) {
+        self.log(msg, LogLevel::Standard, LogStyle::Error);
+    }
+
+    pub fn success<S: AsRef<str>>(&self, msg: S) {
+        self.log(msg, LogLevel::Standard, LogStyle::Success);
+    }
+
+    pub fn log<S: AsRef<str>>(&self, msg: S, log_level: LogLevel, log_style: LogStyle) {
+        let log = match log_level {
+            LogLevel::Standard => true,
+            LogLevel::Verbose => matches!(self.log_level, LogLevel::Verbose),
+        };
+
+        if log {
+            // We currently aren't worried about logging failures.
+            match log_style {
+                LogStyle::Info => {
+                    let _ = self.out.write_line(msg.as_ref());
+                }
+                LogStyle::Status => {
+                    let _ = self
+                        .out
+                        .write_line(&format!("\n{}", STATUS.apply_to(msg.as_ref())));
+                }
+                LogStyle::Warning => {
+                    let _ = self
+                        .err
+                        .write_line(&WARN.apply_to(msg.as_ref()).to_string());
+                }
+                LogStyle::Error => {
+                    let _ = self
+                        .err
+                        .write_line(&ERROR.apply_to(msg.as_ref()).to_string());
+                }
+                LogStyle::Success => {
+                    let _ = self
+                        .out
+                        .write_line(&SUCCESS.apply_to(msg.as_ref()).to_string());
+                }
+            };
+        }
+    }
+}

--- a/pagefind/src/main.rs
+++ b/pagefind/src/main.rs
@@ -32,7 +32,7 @@ async fn main() {
             configs.join(", ")
         );
         eprintln!("Pagefind only supports loading one configuration file format, please ensure only one file exists.");
-        return;
+        std::process::exit(1);
     }
 
     for config in configs {
@@ -43,7 +43,8 @@ async fn main() {
         } else if config.ends_with("yaml") || config.ends_with("yml") {
             Layer::Yaml
         } else {
-            panic!("Unknown config file format");
+            eprintln!("Unknown config file format {}", config);
+            std::process::exit(1);
         };
         config_layers.push(layer_fn(config.into()));
     }
@@ -59,11 +60,12 @@ async fn main() {
                 runner.run().await;
 
                 let duration = start.elapsed();
-                println!(
+
+                runner.options.logger.status(&format!(
                     "Finished in {}.{} seconds",
                     duration.as_secs(),
                     duration.subsec_millis()
-                );
+                ));
 
                 if config.serve {
                     pagefind::serve::serve_dir(PathBuf::from(config.source)).await;
@@ -95,6 +97,7 @@ async fn main() {
                     eprintln!("Unknown Error");
                 }
             }
+            std::process::exit(1);
         }
     }
 }

--- a/pagefind/src/options.rs
+++ b/pagefind/src/options.rs
@@ -39,6 +39,13 @@ pub struct PagefindInboundConfig {
 
     #[clap(
         long,
+        help = "Ignore any detected languages and index the whole site as a single language. Expects an ISO 639-1 code."
+    )]
+    #[clap(required = false)]
+    pub force_language: Option<String>,
+
+    #[clap(
+        long,
         help = "Serve the source directory after creating the search index"
     )]
     #[clap(required = false)]
@@ -78,6 +85,7 @@ pub struct SearchOptions {
     pub bundle_dir: PathBuf,
     pub root_selector: String,
     pub glob: String,
+    pub force_language: Option<String>,
     pub verbose: bool,
     pub version: &'static str,
 }
@@ -95,6 +103,7 @@ impl SearchOptions {
                 bundle_dir: PathBuf::from(config.bundle_dir),
                 root_selector: config.root_selector,
                 glob: config.glob,
+                force_language: config.force_language,
                 verbose: config.verbose,
                 version: env!("CARGO_PKG_VERSION"),
             })

--- a/pagefind/src/output/entry.rs
+++ b/pagefind/src/output/entry.rs
@@ -12,4 +12,5 @@ pub struct PagefindEntryMeta {
 pub struct PagefindEntryLanguage {
     pub hash: String,
     pub wasm: Option<String>,
+    pub page_count: usize,
 }

--- a/pagefind/src/output/entry.rs
+++ b/pagefind/src/output/entry.rs
@@ -1,0 +1,9 @@
+use hashbrown::HashMap;
+
+use serde::Serialize;
+
+#[derive(Serialize, Debug)]
+pub struct PagefindEntryMeta {
+    pub version: &'static str,
+    pub languages: HashMap<String, String>,
+}

--- a/pagefind/src/output/entry.rs
+++ b/pagefind/src/output/entry.rs
@@ -5,5 +5,11 @@ use serde::Serialize;
 #[derive(Serialize, Debug)]
 pub struct PagefindEntryMeta {
     pub version: &'static str,
-    pub languages: HashMap<String, String>,
+    pub languages: HashMap<String, PagefindEntryLanguage>,
+}
+
+#[derive(Serialize, Debug)]
+pub struct PagefindEntryLanguage {
+    pub hash: String,
+    pub wasm: Option<String>,
 }

--- a/pagefind/src/output/mod.rs
+++ b/pagefind/src/output/mod.rs
@@ -125,7 +125,11 @@ impl PagefindIndexes {
                     WriteBehavior::None,
                 ));
             } else {
-                eprintln!("TODO: Error: No wasm for {}", self.language);
+                options.logger.v_warn(format!(
+                    "Note: Pagefind doesn't support stemming for the language {}. \n\
+                    Searching will still work, but will not match across root words.",
+                    self.language
+                ));
             }
         }
 

--- a/pagefind/src/output/mod.rs
+++ b/pagefind/src/output/mod.rs
@@ -54,6 +54,7 @@ const SEARCH_JS: &str = include_str!(concat!(
 ));
 
 pub struct LanguageMeta {
+    pub page_count: usize,
     pub language: String,
     pub hash: String,
     pub wasm: Option<String>,
@@ -73,6 +74,7 @@ pub async fn write_common(options: &SearchOptions, language_indexes: Vec<Languag
                 entry::PagefindEntryLanguage {
                     hash: i.hash,
                     wasm: i.wasm,
+                    page_count: i.page_count,
                 },
             )
         })),
@@ -180,6 +182,7 @@ impl PagefindIndexes {
         join_all(files).await;
 
         LanguageMeta {
+            page_count: self.fragments.len(),
             language: self.language,
             hash: self.meta_index.0,
             wasm: wasm_file,

--- a/pagefind/src/output/mod.rs
+++ b/pagefind/src/output/mod.rs
@@ -7,72 +7,127 @@ use crate::SearchOptions;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use futures::future::join_all;
+use hashbrown::HashMap;
+use include_dir::{include_dir, Dir};
 use minifier::js::minify;
 use tokio::fs::{create_dir_all, File};
 use tokio::io::AsyncWriteExt;
 use tokio::time::sleep;
 
-const WEB_WASM: &[u8] = include_bytes!(concat!(
-    "../../vendor/pagefind_web_bg.",
+mod entry;
+
+const PAGEFIND_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+const GENERIC_WEB_WASM: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/vendor/wasm/pagefind_web_bg.unknown.",
     env!("CARGO_PKG_VERSION"),
-    ".wasm"
+    ".wasm.gz"
 ));
+const WEB_WASM_FILES: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/vendor/wasm");
+
 const WEB_JS: &str = include_str!(concat!(
-    "../../vendor/pagefind_web.",
+    env!("CARGO_MANIFEST_DIR"),
+    "/vendor/pagefind_web.",
     env!("CARGO_PKG_VERSION"),
     ".js"
 ));
 const WEB_UI_JS: &[u8] = include_bytes!(concat!(
-    "../../vendor/pagefind_ui.",
+    env!("CARGO_MANIFEST_DIR"),
+    "/vendor/pagefind_ui.",
     env!("CARGO_PKG_VERSION"),
     ".js"
 ));
 const WEB_UI_CSS: &[u8] = include_bytes!(concat!(
-    "../../vendor/pagefind_ui.",
+    env!("CARGO_MANIFEST_DIR"),
+    "/vendor/pagefind_ui.",
     env!("CARGO_PKG_VERSION"),
     ".css"
 ));
-const GUNZIP_JS: &str = include_str!("./stubs/gz.js");
-const SEARCH_JS: &str = include_str!("./stubs/search.js");
+const GUNZIP_JS: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/src/output/stubs/gz.js"
+));
+const SEARCH_JS: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/src/output/stubs/search.js"
+));
+
+pub async fn write_common(options: &SearchOptions, language_indexes: Vec<(String, String)>) {
+    let outdir = options.source.join(&options.bundle_dir);
+
+    let js_version = format!("const pagefind_version = \"{PAGEFIND_VERSION}\";");
+    let js = minify(&format!("{js_version}\n{WEB_JS}\n{GUNZIP_JS}\n{SEARCH_JS}"));
+
+    let entry_meta = entry::PagefindEntryMeta {
+        version: PAGEFIND_VERSION,
+        languages: HashMap::from_iter(language_indexes),
+    };
+    let encoded_entry_meta = serde_json::to_string(&entry_meta).unwrap();
+
+    let files = vec![
+        write(
+            outdir.join("pagefind.js"),
+            vec![js.as_bytes()],
+            Compress::None,
+            WriteBehavior::None,
+        ),
+        write(
+            outdir.join("pagefind-ui.js"),
+            vec![WEB_UI_JS],
+            Compress::None,
+            WriteBehavior::None,
+        ),
+        write(
+            outdir.join("pagefind-ui.css"),
+            vec![WEB_UI_CSS],
+            Compress::None,
+            WriteBehavior::None,
+        ),
+        write(
+            outdir.join("wasm.unknown.pagefind"),
+            vec![GENERIC_WEB_WASM],
+            Compress::None,
+            WriteBehavior::None,
+        ),
+        write(
+            outdir.join("pagefind-entry.json"),
+            vec![encoded_entry_meta.as_bytes()],
+            Compress::None,
+            WriteBehavior::None,
+        ),
+    ];
+
+    join_all(files).await;
+}
 
 impl PagefindIndexes {
     pub async fn write_files(self, options: &SearchOptions) {
         let outdir = options.source.join(&options.bundle_dir);
 
-        let js = minify(&format!("{}\n{}\n{}", WEB_JS, GUNZIP_JS, SEARCH_JS));
+        let mut files = vec![write(
+            outdir.join(format!("pagefind.{}.pf_meta", &self.meta_index.0)),
+            vec![&self.meta_index.1],
+            Compress::GZ,
+            WriteBehavior::Immutable,
+        )];
 
-        let mut files = vec![
-            write(
-                outdir.join("pagefind.js"),
-                vec![js.as_bytes()],
-                Compress::None,
-                WriteBehavior::None,
-            ),
-            write(
-                outdir.join("pagefind-ui.js"),
-                vec![WEB_UI_JS],
-                Compress::None,
-                WriteBehavior::None,
-            ),
-            write(
-                outdir.join("pagefind-ui.css"),
-                vec![WEB_UI_CSS],
-                Compress::None,
-                WriteBehavior::None,
-            ),
-            write(
-                outdir.join("wasm.pagefind"),
-                vec![WEB_WASM],
-                Compress::GZ,
-                WriteBehavior::None,
-            ),
-            write(
-                outdir.join("pagefind.pf_meta"),
-                vec![&self.meta_index],
-                Compress::GZ,
-                WriteBehavior::None,
-            ),
-        ];
+        if self.language != "unknown" {
+            if let Some(wasm) = WEB_WASM_FILES.get_file(format!(
+                "pagefind_web_bg.{}.{}.wasm.gz",
+                self.language,
+                env!("CARGO_PKG_VERSION")
+            )) {
+                files.push(write(
+                    outdir.join(format!("wasm.{}.pagefind", self.language)),
+                    vec![wasm.contents()],
+                    Compress::None,
+                    WriteBehavior::None,
+                ));
+            } else {
+                eprintln!("TODO: Error: No wasm for {}", self.language);
+            }
+        }
 
         files.extend(self.fragments.iter().map(|(hash, fragment)| {
             write(

--- a/pagefind/src/output/mod.rs
+++ b/pagefind/src/output/mod.rs
@@ -113,9 +113,10 @@ impl PagefindIndexes {
         )];
 
         if self.language != "unknown" {
+            let base_language = self.language.split('-').next().unwrap();
             if let Some(wasm) = WEB_WASM_FILES.get_file(format!(
                 "pagefind_web_bg.{}.{}.wasm.gz",
-                self.language,
+                base_language,
                 env!("CARGO_PKG_VERSION")
             )) {
                 files.push(write(
@@ -127,7 +128,7 @@ impl PagefindIndexes {
             } else {
                 options.logger.v_warn(format!(
                     "Note: Pagefind doesn't support stemming for the language {}. \n\
-                    Searching will still work, but will not match across root words.",
+                    Search will still work, but will not match across root words.",
                     self.language
                 ));
             }

--- a/pagefind/src/output/stubs/search.js
+++ b/pagefind/src/output/stubs/search.js
@@ -2,6 +2,8 @@
 class Pagefind {
     constructor() {
         this.backend = wasm_bindgen;
+        this.languages = null;
+        this.primaryLanguage = "unknown";
         this.wasm = null;
         this.searchIndex = null;
         this.searchMeta = null;
@@ -34,9 +36,40 @@ class Pagefind {
         } catch (e) {
             console.warn("Pagefind couldn't determine the base of the bundle from the import path. Falling back to the default.");
         }
-        await Promise.all([this.loadWasm(), this.loadMeta()]);
+        await this.loadEntry();
+        let { language, index } = this.findLanguage();
+
+        await Promise.all([this.loadWasm(language), this.loadMeta(index)]);
         window.tmp_pagefind = this.backend;
         this.raw_ptr = this.backend.init_pagefind(new Uint8Array(this.searchMeta));
+    }
+
+    findLanguage() {
+        if (document?.querySelector) {
+            const langCode = document.querySelector("html").getAttribute("lang") || "unknown";
+            this.primaryLanguage = langCode.split("-")[0];
+        }
+        let language = this.primaryLanguage, index = null;
+        if (this.languages) {
+            index = this.languages[language];
+            if (!index && this.languages["unknown"]) {
+                language = "unknown";
+                index = this.languages["unknown"];
+            }
+            if (!index && this.languages["en"]) {
+                language = "en";
+                index = this.languages["en"];
+            }
+            if (!index && Object.values(this.languages).length) {
+                language = Object.entries(this.languages)[0];
+                index = Object.values(this.languages)[0];
+            }
+            if (!index) {
+                throw new Error("Pagefind Error: No language indexes found.");
+            }
+        }
+
+        return { language, index };
     }
 
     decompress(data, file = "unknown file") {
@@ -53,13 +86,29 @@ class Pagefind {
         return data.slice(12);
     }
 
-    async loadMeta() {
+    async loadEntry() {
         try {
-            // We always load a fresh copy of the metadata,
+            // We always load a fresh copy of the entry metadata,
             // as it ensures we don't try to load an old build's chunks,
-            // and it's (hopefully) a small enough file to not be a worry.
-            // TODO:     ^^^^^^^^^
-            let compressed_meta = await fetch(`${this.basePath}pagefind.pf_meta?ts=${Date.now()}`);
+            let entry_json = await fetch(`${this.basePath}pagefind-entry.json?ts=${Date.now()}`);
+            entry_json = await entry_json.json();
+            this.languages = entry_json.languages;
+            if (entry_json.version !== pagefind_version) {
+                console.warn([
+                    "Pagefind JS version doesn't match the version in your search index.",
+                    `Pagefind JS: ${pagefind_version}. Pagefind index: ${entry_json.version}`,
+                    "If you upgraded Pagefind recently, you likely have a cached pagefind.js file.",
+                    "If you encounter any search errors, try clearing your cache."
+                ].join('\n'));
+            }
+        } catch (e) {
+            console.error(`Failed to load Pagefind metadata:\n${e.toString()}`);
+        }
+    }
+
+    async loadMeta(index) {
+        try {
+            let compressed_meta = await fetch(`${this.basePath}pagefind.${index}.pf_meta`);
             compressed_meta = await compressed_meta.arrayBuffer();
             this.searchMeta = this.decompress(new Uint8Array(compressed_meta), "Pagefind metadata");
         } catch (e) {
@@ -67,11 +116,13 @@ class Pagefind {
         }
     }
 
-    async loadWasm() {
+    async loadWasm(language) {
         try {
-            let compressed_wasm = await fetch(`${this.basePath}wasm.pagefind`);
+            const wasm_url = `${this.basePath}wasm.${language}.pagefind`;
+            let compressed_wasm = await fetch(wasm_url);
             compressed_wasm = await compressed_wasm.arrayBuffer();
-            this.wasm = await this.backend(this.decompress(new Uint8Array(compressed_wasm), "Pagefind WebAssembly"));
+            const final_wasm = this.decompress(new Uint8Array(compressed_wasm), "Pagefind WebAssembly");
+            this.wasm = await this.backend(final_wasm);
         } catch (e) {
             console.error(`Failed to load the Pagefind WASM:\n${e.toString()}`);
         }
@@ -243,5 +294,6 @@ class Pagefind {
 const pagefind = new Pagefind();
 
 export const options = (options) => pagefind.options(options);
+// TODO: Add a language function that can change the language before pagefind is initialised
 export const search = async (term, options) => await pagefind.search(term, options);
 export const filters = async () => await pagefind.filters();

--- a/pagefind/src/output/stubs/search.js
+++ b/pagefind/src/output/stubs/search.js
@@ -51,6 +51,7 @@ class Pagefind {
             this.primaryLanguage = langCode.toLocaleLowerCase();
         }
         let language = this.primaryLanguage;
+
         if (this.languages) {
             let index = this.languages[language];
             if (index) return { language, index };
@@ -63,12 +64,10 @@ class Pagefind {
             index = this.languages["unknown"];
             if (index) return { language, index };
 
-            language = "en";
-            index = this.languages["en"];
-            if (index) return { language, index };
+            let topLang = Object.entries(this.languages).sort(([, a], [, b]) => b.page_count - a.page_count)[0];
 
-            language = Object.entries(this.languages)[0];
-            index = Object.values(this.languages)[0];
+            language = topLang[0];
+            index = topLang[1];
             if (index) return { language, index };
 
             throw new Error("Pagefind Error: No language indexes found.");

--- a/pagefind/src/output/stubs/search.js
+++ b/pagefind/src/output/stubs/search.js
@@ -169,14 +169,24 @@ class Pagefind {
         }
         let fragment = await this.loaded_fragments[hash];
 
-        let fragment_words = fragment.content.split(/[\r\n\s]+/g);
+        let fragment_words = [];
+        if (fragment.content.includes('\u200B')) {
+            // If segmentation was run on the backend, count words by ZWS boundaries
+            fragment_words = fragment.content.split('\u200B');
+        } else {
+            fragment_words = fragment.content.split(/[\r\n\s]+/g);
+        }
         for (let word of locations) {
             fragment_words[word] = `<mark>${fragment_words[word]}</mark>`;
         }
-        fragment.excerpt = fragment_words.slice(excerpt[0], excerpt[0] + excerpt[1]).join(' ');
+        fragment.excerpt = fragment_words.slice(excerpt[0], excerpt[0] + excerpt[1]).join(' ').trim();
         if (!fragment.raw_url) {
             fragment.raw_url = fragment.url;
             fragment.url = this.fullUrl(fragment.raw_url);
+        }
+        if (!fragment.raw_content) {
+            fragment.raw_content = fragment.content;
+            fragment.content = fragment.content.replace(/\u200B/g, '');
         }
         return fragment;
     }

--- a/pagefind/src/output/stubs/search.js
+++ b/pagefind/src/output/stubs/search.js
@@ -47,29 +47,33 @@ class Pagefind {
     findLanguage() {
         if (document?.querySelector) {
             const langCode = document.querySelector("html").getAttribute("lang") || "unknown";
-            this.primaryLanguage = langCode.split("-")[0];
+            this.primaryLanguage = langCode.toLocaleLowerCase();
         }
-        let language = this.primaryLanguage, index = null;
+        let language = this.primaryLanguage;
         if (this.languages) {
+            let index = this.languages[language];
+            if (index) return { language, index };
+
+            language = language.split("-")[0];
             index = this.languages[language];
-            if (!index && this.languages["unknown"]) {
-                language = "unknown";
-                index = this.languages["unknown"];
-            }
-            if (!index && this.languages["en"]) {
-                language = "en";
-                index = this.languages["en"];
-            }
-            if (!index && Object.values(this.languages).length) {
-                language = Object.entries(this.languages)[0];
-                index = Object.values(this.languages)[0];
-            }
-            if (!index) {
-                throw new Error("Pagefind Error: No language indexes found.");
-            }
+            if (index) return { language, index };
+
+            language = "unknown";
+            index = this.languages["unknown"];
+            if (index) return { language, index };
+
+            language = "en";
+            index = this.languages["en"];
+            if (index) return { language, index };
+
+            language = Object.entries(this.languages)[0];
+            index = Object.values(this.languages)[0];
+            if (index) return { language, index };
+
+            throw new Error("Pagefind Error: No language indexes found.");
         }
 
-        return { language, index };
+        return { language, index: null };
     }
 
     decompress(data, file = "unknown file") {

--- a/pagefind/src/output/stubs/search.js
+++ b/pagefind/src/output/stubs/search.js
@@ -169,24 +169,26 @@ class Pagefind {
         }
         let fragment = await this.loaded_fragments[hash];
 
+        if (!fragment.raw_content) {
+            fragment.raw_content = fragment.content;
+            fragment.content = fragment.content.replace(/\u200B/g, '');
+        }
+
+        let is_zws_delimited = fragment.raw_content.includes('\u200B');
         let fragment_words = [];
-        if (fragment.content.includes('\u200B')) {
+        if (is_zws_delimited) {
             // If segmentation was run on the backend, count words by ZWS boundaries
-            fragment_words = fragment.content.split('\u200B');
+            fragment_words = fragment.raw_content.split('\u200B');
         } else {
-            fragment_words = fragment.content.split(/[\r\n\s]+/g);
+            fragment_words = fragment.raw_content.split(/[\r\n\s]+/g);
         }
         for (let word of locations) {
             fragment_words[word] = `<mark>${fragment_words[word]}</mark>`;
         }
-        fragment.excerpt = fragment_words.slice(excerpt[0], excerpt[0] + excerpt[1]).join(' ').trim();
+        fragment.excerpt = fragment_words.slice(excerpt[0], excerpt[0] + excerpt[1]).join(is_zws_delimited ? '' : ' ').trim();
         if (!fragment.raw_url) {
             fragment.raw_url = fragment.url;
             fragment.url = this.fullUrl(fragment.raw_url);
-        }
-        if (!fragment.raw_content) {
-            fragment.raw_content = fragment.content;
-            fragment.content = fragment.content.replace(/\u200B/g, '');
         }
         return fragment;
     }

--- a/pagefind/src/output/stubs/search.js
+++ b/pagefind/src/output/stubs/search.js
@@ -38,8 +38,9 @@ class Pagefind {
         }
         await this.loadEntry();
         let { language, index } = this.findLanguage();
+        let lang_wasm = index.wasm ? index.wasm : "unknown";
 
-        await Promise.all([this.loadWasm(language), this.loadMeta(index)]);
+        await Promise.all([this.loadWasm(lang_wasm), this.loadMeta(index.hash)]);
         window.tmp_pagefind = this.backend;
         this.raw_ptr = this.backend.init_pagefind(new Uint8Array(this.searchMeta));
     }

--- a/pagefind/test.sh
+++ b/pagefind/test.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 cargo build --release
-TEST_BINARY=../target/release/pagefind npx humane
+TEST_BINARY=../target/release/pagefind npx humane@latest

--- a/pagefind/test.sh
+++ b/pagefind/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-cargo build --release
+cargo build --release --features extended
 if [ -z "$1" ]; then
     TEST_BINARY=../target/release/pagefind npx -y humane@latest
 else

--- a/pagefind/test.sh
+++ b/pagefind/test.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 
 cargo build --release
-TEST_BINARY=../target/release/pagefind npx humane@latest
+if [ -z "$1" ]; then
+    TEST_BINARY=../target/release/pagefind npx -y humane@latest
+else
+    TEST_BINARY=../target/release/pagefind npx -y humane@latest --name "$1"
+fi

--- a/pagefind_stem/Cargo.toml
+++ b/pagefind_stem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pagefind_stem"
-version = "0.1.0"
+version = "0.2.0"
 # Imports would have to change for a newer edition,
 # and I don't want to have to edit snowball's rust files
 edition = "2015"

--- a/pagefind_stem/src/snowball/algorithms/mod.rs
+++ b/pagefind_stem/src/snowball/algorithms/mod.rs
@@ -1,4 +1,3 @@
-
 #[cfg(feature = "arabic")]
 pub mod arabic;
 #[cfg(feature = "armenian")]
@@ -129,6 +128,80 @@ pub enum Algorithm {
     Turkish,
     #[cfg(feature = "yiddish")]
     Yiddish,
+}
+
+/// Retrieves the primary algorithm that this crate was compiled with.
+/// Allows consumer crates to change algorithm based only on feature flag usage,
+/// without changes to the consuming code.
+/// Assumes that the crate was compiled with only one feature flag enabled.
+/// If multiple flags are enabled, no guarantee is given on which algorithm is returned
+/// (though it will likely be alphabetical).
+pub fn get_algorithm() -> Option<fn(&mut super::SnowballEnv) -> bool> {
+    #[cfg(feature = "arabic")]
+    return Some(arabic::stem);
+    #[cfg(feature = "armenian")]
+    return Some(armenian::stem);
+    #[cfg(feature = "basque")]
+    return Some(basque::stem);
+    #[cfg(feature = "catalan")]
+    return Some(catalan::stem);
+    #[cfg(feature = "danish")]
+    return Some(danish::stem);
+    #[cfg(feature = "dutch")]
+    return Some(dutch::stem);
+    #[cfg(feature = "english")]
+    return Some(english::stem);
+    #[cfg(feature = "finnish")]
+    return Some(finnish::stem);
+    #[cfg(feature = "french")]
+    return Some(french::stem);
+    #[cfg(feature = "german")]
+    return Some(german::stem);
+    #[cfg(feature = "german2")]
+    return Some(german2::stem);
+    #[cfg(feature = "greek")]
+    return Some(greek::stem);
+    #[cfg(feature = "hindi")]
+    return Some(hindi::stem);
+    #[cfg(feature = "hungarian")]
+    return Some(hungarian::stem);
+    #[cfg(feature = "indonesian")]
+    return Some(indonesian::stem);
+    #[cfg(feature = "irish")]
+    return Some(irish::stem);
+    #[cfg(feature = "italian")]
+    return Some(italian::stem);
+    #[cfg(feature = "kraaij_pohlmann")]
+    return Some(kraaij_pohlmann::stem);
+    #[cfg(feature = "lithuanian")]
+    return Some(lithuanian::stem);
+    #[cfg(feature = "lovins")]
+    return Some(lovins::stem);
+    #[cfg(feature = "nepali")]
+    return Some(nepali::stem);
+    #[cfg(feature = "norwegian")]
+    return Some(norwegian::stem);
+    #[cfg(feature = "porter")]
+    return Some(porter::stem);
+    #[cfg(feature = "portuguese")]
+    return Some(portuguese::stem);
+    #[cfg(feature = "romanian")]
+    return Some(romanian::stem);
+    #[cfg(feature = "russian")]
+    return Some(russian::stem);
+    #[cfg(feature = "serbian")]
+    return Some(serbian::stem);
+    #[cfg(feature = "spanish")]
+    return Some(spanish::stem);
+    #[cfg(feature = "swedish")]
+    return Some(swedish::stem);
+    #[cfg(feature = "tamil")]
+    return Some(tamil::stem);
+    #[cfg(feature = "turkish")]
+    return Some(turkish::stem);
+    #[cfg(feature = "yiddish")]
+    return Some(yiddish::stem);
+    None
 }
 
 impl From<Algorithm> for fn(&mut super::SnowballEnv) -> bool {

--- a/pagefind_ui/build.js
+++ b/pagefind_ui/build.js
@@ -1,5 +1,6 @@
 import esbuild from 'esbuild';
 import path from 'path';
+import ImportGlobPlugin from "esbuild-plugin-import-glob";
 import sveltePlugin from "esbuild-svelte";
 import { createRequire } from "module";
 import { fileURLToPath } from 'url';
@@ -31,6 +32,7 @@ const build = async () => {
         entryPoints: [path.join(__dirname, 'ui.js')],
         entryNames: `pagefind_[name].${version}`,
         plugins: [
+            ImportGlobPlugin.default(),
             sveltePlugin({ compileOptions: { css: false } }),
             sveltefixPlugin
         ],
@@ -49,6 +51,7 @@ const serve = async () => {
         outdir: path.join(__dirname, "dev_files/_pagefind"),
         entryPoints: [path.join(__dirname, 'ui.js')],
         plugins: [
+            ImportGlobPlugin.default(),
             sveltePlugin({ compileOptions: { css: false } }),
             sveltefixPlugin
         ],

--- a/pagefind_ui/package-lock.json
+++ b/pagefind_ui/package-lock.json
@@ -1,16 +1,65 @@
 {
   "name": "pagefind_ui",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pagefind_ui",
-      "license": "ISC",
+      "version": "0.0.0",
+      "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.14.42",
+        "esbuild-plugin-import-glob": "^0.1.1",
         "esbuild-svelte": "^0.7.1",
         "svelte": "^3.48.0"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/esbuild": {
@@ -304,6 +353,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/esbuild-plugin-import-glob": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/esbuild-plugin-import-glob/-/esbuild-plugin-import-glob-0.1.1.tgz",
+      "integrity": "sha512-yAFH+9AoIcsQkODSx0KUPRv1FeJUN6Tef8vkPQMcuVkc2vXYneYKsHhOiFS/yIsg5bQ70HHtAlXVA1uTjgoJXg==",
+      "dev": true,
+      "dependencies": {
+        "fast-glob": "^3.2.5"
+      }
+    },
     "node_modules/esbuild-sunos-64": {
       "version": "0.14.42",
       "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.42.tgz",
@@ -381,6 +439,172 @@
         "node": ">=12"
       }
     },
+    "node_modules/fast-glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "node_modules/svelte": {
       "version": "3.48.0",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.48.0.tgz",
@@ -389,9 +613,56 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
     }
   },
   "dependencies": {
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
     "esbuild": {
       "version": "0.14.42",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.42.tgz",
@@ -532,6 +803,15 @@
       "dev": true,
       "optional": true
     },
+    "esbuild-plugin-import-glob": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/esbuild-plugin-import-glob/-/esbuild-plugin-import-glob-0.1.1.tgz",
+      "integrity": "sha512-yAFH+9AoIcsQkODSx0KUPRv1FeJUN6Tef8vkPQMcuVkc2vXYneYKsHhOiFS/yIsg5bQ70HHtAlXVA1uTjgoJXg==",
+      "dev": true,
+      "requires": {
+        "fast-glob": "^3.2.5"
+      }
+    },
     "esbuild-sunos-64": {
       "version": "0.14.42",
       "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.42.tgz",
@@ -567,11 +847,124 @@
       "dev": true,
       "optional": true
     },
+    "fast-glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      }
+    },
+    "fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      }
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
+    },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "svelte": {
       "version": "3.48.0",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.48.0.tgz",
       "integrity": "sha512-fN2YRm/bGumvjUpu6yI3BpvZnpIm9I6A7HR4oUNYd7ggYyIwSA/BX7DJ+UXXffLp6XNcUijyLvttbPVCYa/3xQ==",
       "dev": true
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
     }
   }
 }

--- a/pagefind_ui/package.json
+++ b/pagefind_ui/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "devDependencies": {
     "esbuild": "^0.14.42",
+    "esbuild-plugin-import-glob": "^0.1.1",
     "esbuild-svelte": "^0.7.1",
     "svelte": "^3.48.0"
   }

--- a/pagefind_ui/svelte/filters.svelte
+++ b/pagefind_ui/svelte/filters.svelte
@@ -1,6 +1,7 @@
 <script>
     export let available_filters = null;
     export let show_empty_filters = true;
+    export let translations;
     export const selected_filters = {};
 
     let initialized = false;
@@ -21,7 +22,9 @@
 
 {#if available_filters && Object.entries(available_filters).length}
     <fieldset class="pagefind-ui__filter-panel">
-        <legend class="pagefind-ui__filter-panel-label">Filters</legend>
+        <legend class="pagefind-ui__filter-panel-label"
+            >{translations.strings.filters_label}</legend
+        >
         {#each Object.entries(available_filters) as [filter, values]}
             <details class="pagefind-ui__filter-block" open={default_open}>
                 <summary class="pagefind-ui__filter-name"

--- a/pagefind_ui/svelte/ui.svelte
+++ b/pagefind_ui/svelte/ui.svelte
@@ -42,6 +42,7 @@
     onMount(() => {
         let lang =
             document?.querySelector?.("html")?.getAttribute?.("lang") || "en";
+        lang = lang.toLocaleLowerCase();
         if (availableTranslations[lang]) {
             translations = availableTranslations[lang];
         } else {

--- a/pagefind_ui/svelte/ui.svelte
+++ b/pagefind_ui/svelte/ui.svelte
@@ -1,7 +1,22 @@
 <script>
+    import { onMount } from "svelte";
+
     import Result from "./result.svelte";
     import Filters from "./filters.svelte";
     import Reset from "./reset.svelte";
+
+    import * as translationFiles from "../translations/*.json";
+
+    const availableTranslations = {},
+        languages = translationFiles.filenames.map(
+            (file) => file.match(/(\w+)\.json$/)[1]
+        );
+    for (let i = 0; i < languages.length; i++) {
+        availableTranslations[languages[i]] = {
+            language: languages[i],
+            ...translationFiles.default[i],
+        };
+    }
 
     export let base_path = "/_pagefind/";
     export let reset_styles = true;
@@ -22,6 +37,20 @@
     let initial_filters = null;
     let available_filters = null;
     let selected_filters = {};
+    let translations = availableTranslations["en"];
+
+    onMount(() => {
+        let lang =
+            document?.querySelector?.("html")?.getAttribute?.("lang") || "en";
+        if (availableTranslations[lang]) {
+            translations = availableTranslations[lang];
+        } else {
+            lang = lang.split("-")[0];
+            if (availableTranslations[lang]) {
+                translations = availableTranslations[lang];
+            }
+        }
+    });
 
     $: search(val, selected_filters);
 
@@ -91,7 +120,7 @@
     <form
         class="pagefind-ui__form"
         role="search"
-        aria-label="Search this site"
+        aria-label={translations.strings.search_label}
         action="javascript:void(0);"
         on:submit={(e) => e.preventDefault()}
     >
@@ -100,7 +129,7 @@
             on:focus={init}
             bind:value={val}
             type="text"
-            placeholder="Search"
+            placeholder={translations.strings.placeholder}
         />
 
         <div class="pagefind-ui__drawer" class:pagefind-ui__hidden={!searched}>
@@ -108,6 +137,7 @@
                 <Filters
                     {show_empty_filters}
                     {available_filters}
+                    {translations}
                     bind:selected_filters
                 />
             {/if}
@@ -117,23 +147,38 @@
                     {#if loading}
                         {#if search_term}
                             <p class="pagefind-ui__message">
-                                Searching for "{search_term.replace(
-                                    /^"+|"+$/g,
-                                    ""
-                                )}"...
+                                {translations.strings.searching.replace(
+                                    /\[SEARCH_TERM\]/,
+                                    search_term
+                                )}
                             </p>
-                        {:else}
-                            <p class="pagefind-ui__message">Filtering...</p>
                         {/if}
                     {:else}
                         <p class="pagefind-ui__message">
-                            {searchResult.results.length} result{searchResult
-                                .results.length === 1
-                                ? ""
-                                : "s"}
-                            {search_term
-                                ? `for "${search_term.replace(/^"+|"+$/g, "")}"`
-                                : ""}
+                            {#if searchResult.results.length === 0}
+                                {translations.strings.zero_results.replace(
+                                    /\[SEARCH_TERM\]/,
+                                    search_term
+                                )}
+                            {:else if searchResult.results.length === 1}
+                                {translations.strings.one_result
+                                    .replace(/\[SEARCH_TERM\]/, search_term)
+                                    .replace(
+                                        /\[COUNT\]/,
+                                        new Intl.NumberFormat(
+                                            translations.language
+                                        ).format(1)
+                                    )}
+                            {:else}
+                                {translations.strings.many_results
+                                    .replace(/\[SEARCH_TERM\]/, search_term)
+                                    .replace(
+                                        /\[COUNT\]/,
+                                        new Intl.NumberFormat(
+                                            translations.language
+                                        ).format(searchResult.results.length)
+                                    )}
+                            {/if}
                         </p>
                         <ol class="pagefind-ui__results">
                             {#each searchResult.results.slice(0, show) as result (result.id)}
@@ -144,7 +189,8 @@
                             <button
                                 type="button"
                                 class="pagefind-ui__button"
-                                on:click={showMore}>Load more results</button
+                                on:click={showMore}
+                                >{translations.strings.load_more}</button
                             >
                         {/if}
                     {/if}

--- a/pagefind_ui/translations/af.json
+++ b/pagefind_ui/translations/af.json
@@ -1,0 +1,18 @@
+{
+    "thanks_to": "Jan Claasen",
+    "comments": "",
+    "direction": "ltr",
+    "strings": {
+        "placeholder": "Soek",
+        "clear_search": "Opruim",
+        "load_more": "Laai nog resultate",
+        "search_label": "Soek hierdie webwerf",
+        "filters_label": "Filters",
+        "zero_results": "Geen resultate vir [SEARCH_TERM]",
+        "many_results": "[COUNT] resultate vir [SEARCH_TERM]",
+        "one_result": "[COUNT] resultate vir [SEARCH_TERM]",
+        "alt_search": "Geen resultate vir [SEARCH_TERM]. Toon resultate vir [DIFFERENT_TERM] in plaas daarvan",
+        "search_suggestion": "Geen resultate vir [SEARCH_TERM]. Probeer eerder een van die volgende terme:",
+        "searching": "[SEARCH_TERM]..."
+    }
+}

--- a/pagefind_ui/translations/af.json
+++ b/pagefind_ui/translations/af.json
@@ -13,6 +13,6 @@
         "one_result": "[COUNT] resultate vir [SEARCH_TERM]",
         "alt_search": "Geen resultate vir [SEARCH_TERM]. Toon resultate vir [DIFFERENT_TERM] in plaas daarvan",
         "search_suggestion": "Geen resultate vir [SEARCH_TERM]. Probeer eerder een van die volgende terme:",
-        "searching": "[SEARCH_TERM]..."
+        "searching": "Soek vir [SEARCH_TERM]"
     }
 }

--- a/pagefind_ui/translations/de.json
+++ b/pagefind_ui/translations/de.json
@@ -13,6 +13,6 @@
         "one_result": "[COUNT] Ergebnis für [SEARCH_TERM]",
         "alt_search": "Keine Ergebnisse für [SEARCH_TERM]. Stattdessen werden Ergebnisse für [DIFFERENT_TERM] angezeigt",
         "search_suggestion": "Keine Ergebnisse für [SEARCH_TERM]. Versuchen Sie eine der folgenden Suchen:",
-        "searching": "[SEARCH_TERM]..."
+        "searching": "Suche für [SEARCH_TERM]"
     }
 }

--- a/pagefind_ui/translations/de.json
+++ b/pagefind_ui/translations/de.json
@@ -1,0 +1,18 @@
+{
+    "thanks_to": "Jan Claasen",
+    "comments": "",
+    "direction": "ltr",
+    "strings": {
+        "placeholder": "Suche",
+        "clear_search": "Löschen",
+        "load_more": "Mehr Ergebnisse laden",
+        "search_label": "Suche diese Seite",
+        "filters_label": "Filter",
+        "zero_results": "Keine Ergebnisse für [SEARCH_TERM]",
+        "many_results": "[COUNT] Ergebnisse für [SEARCH_TERM]",
+        "one_result": "[COUNT] Ergebnis für [SEARCH_TERM]",
+        "alt_search": "Keine Ergebnisse für [SEARCH_TERM]. Stattdessen werden Ergebnisse für [DIFFERENT_TERM] angezeigt",
+        "search_suggestion": "Keine Ergebnisse für [SEARCH_TERM]. Versuchen Sie eine der folgenden Suchen:",
+        "searching": "[SEARCH_TERM]..."
+    }
+}

--- a/pagefind_ui/translations/en.json
+++ b/pagefind_ui/translations/en.json
@@ -1,0 +1,18 @@
+{
+    "thanks_to": "Liam Bigelow <liam@cloudcannon.com>",
+    "comments": "",
+    "direction": "ltr",
+    "strings": {
+        "placeholder": "Search",
+        "clear_search": "Clear",
+        "load_more": "Load more results",
+        "search_label": "Search this site",
+        "filters_label": "Filters",
+        "zero_results": "No results for [SEARCH_TERM]",
+        "many_results": "[COUNT] results for [SEARCH_TERM]",
+        "one_result": "[COUNT] result for [SEARCH_TERM]",
+        "alt_search": "No results for [SEARCH_TERM]. Showing results for [DIFFERENT_TERM] instead",
+        "search_suggestion": "No results for [SEARCH_TERM]. Try one of the following searches:",
+        "searching": "Searching for [SEARCH_TERM]..."
+    }
+}

--- a/pagefind_ui/translations/ja.json
+++ b/pagefind_ui/translations/ja.json
@@ -1,0 +1,18 @@
+{
+    "thanks_to": "Tate",
+    "comments": "",
+    "direction": "ltr",
+    "strings": {
+        "placeholder": "検索",
+        "clear_search": "消す",
+        "load_more": "もっと読み込む",
+        "search_label": "このサイトを検索",
+        "filters_label": "フィルタ",
+        "zero_results": "[SEARCH_TERM]の検索に一致する件はありませんでした",
+        "many_results": "[SEARCH_TERM]の[COUNT]件の検索結果",
+        "one_result": "[SEARCH_TERM]の[COUNT]件の検索結果",
+        "alt_search": "[SEARCH_TERM]の検索に一致する件はありませんでした。[DIFFERENT_TERM]の検索結果を表示しています",
+        "search_suggestion": "[SEARCH_TERM]の検索に一致する件はありませんでした。次のいずれかの検索を試してください",
+        "searching": "[SEARCH_TERM]を検索しています"
+    }
+}

--- a/pagefind_ui/translations/no.json
+++ b/pagefind_ui/translations/no.json
@@ -1,0 +1,18 @@
+{
+    "thanks_to": "Christopher Wingate",
+    "comments": "",
+    "direction": "ltr",
+    "strings": {
+        "placeholder": "Søk",
+        "clear_search": "Fjern",
+        "load_more": "Last flere resultater",
+        "search_label": "Søk på denne siden",
+        "filters_label": "Filtre",
+        "zero_results": "Ingen resultater for [SEARCH_TERM]",
+        "many_results": "[COUNT] resultater for [SEARCH_TERM]",
+        "one_result": "[COUNT] resultat for [SEARCH_TERM]",
+        "alt_search": "Ingen resultater for [SEARCH_TERM]. Viser resultater for [DIFFERENT_TERM] i stedet",
+        "search_suggestion": "Ingen resultater for [SEARCH_TERM]. Prøv en av disse søkeordene i stedet:",
+        "searching": "Søker etter [SEARCH_TERM]"
+    }
+}

--- a/pagefind_ui/translations/pt.json
+++ b/pagefind_ui/translations/pt.json
@@ -13,6 +13,6 @@
         "one_result": "[COUNT] resultado encontrado para [SEARCH_TERM]",
         "alt_search": "Nenhum resultado encontrado para [SEARCH_TERM]. Exibindo resultados para [DIFFERENT_TERM]",
         "search_suggestion": "Nenhum resultado encontrado para [SEARCH_TERM]. Tente uma das seguintes pesquisas:",
-        "searching": "[SEARCH_TERM]..."
+        "searching": "Pesquisando por [SEARCH_TERM]..."
     }
 }

--- a/pagefind_ui/translations/pt.json
+++ b/pagefind_ui/translations/pt.json
@@ -1,0 +1,18 @@
+{
+    "thanks_to": "Jonatah",
+    "comments": "",
+    "direction": "ltr",
+    "strings": {
+        "placeholder": "Pesquisar",
+        "clear_search": "Limpar",
+        "load_more": "Ver mais resultados",
+        "search_label": "Pesquisar",
+        "filters_label": "Filtros",
+        "zero_results": "Nenhum resultado encontrado para [SEARCH_TERM]",
+        "many_results": "[COUNT] resultados encontrados para [SEARCH_TERM]",
+        "one_result": "[COUNT] resultado encontrado para [SEARCH_TERM]",
+        "alt_search": "Nenhum resultado encontrado para [SEARCH_TERM]. Exibindo resultados para [DIFFERENT_TERM]",
+        "search_suggestion": "Nenhum resultado encontrado para [SEARCH_TERM]. Tente uma das seguintes pesquisas:",
+        "searching": "[SEARCH_TERM]..."
+    }
+}

--- a/pagefind_ui/translations/ru.json
+++ b/pagefind_ui/translations/ru.json
@@ -1,0 +1,18 @@
+{
+    "thanks_to": "Aleksandr Gordeev",
+    "comments": "",
+    "direction": "ltr",
+    "strings": {
+        "placeholder": "Поиск",
+        "clear_search": "Очистить поле",
+        "load_more": "Загрузить еще",
+        "search_label": "Поиск по сайту",
+        "filters_label": "Фильтры",
+        "zero_results": "Ничего не найдено по запросу: [SEARCH_TERM]",
+        "many_results": "[COUNT] результатов по запросу: [SEARCH_TERM]",
+        "one_result": "[COUNT] результат по запросу: [SEARCH_TERM]",
+        "alt_search": "Ничего не найдено по запросу: [SEARCH_TERM]. Показаны результаты по запросу: [DIFFERENT_TERM]",
+        "search_suggestion": "Ничего не найдено по запросу: [SEARCH_TERM]. Попробуйте один из следующих вариантов",
+        "searching": "Поиск по запросу: [SEARCH_TERM]"
+    }
+}

--- a/pagefind_ui/translations/zh.json
+++ b/pagefind_ui/translations/zh.json
@@ -1,0 +1,18 @@
+{
+    "thanks_to": "Amber Song",
+    "comments": "",
+    "direction": "ltr",
+    "strings": {
+        "placeholder": "搜索",
+        "clear_search": "清除",
+        "load_more": "加载更多结果",
+        "search_label": "站内搜索",
+        "filters_label": "筛选",
+        "zero_results": "未找到 [SEARCH_TERM] 的相关结果",
+        "many_results": "找到 [COUNT] 个 [SEARCH_TERM] 的相关结果",
+        "one_result": "找到 [COUNT] 个 [SEARCH_TERM] 的相关结果",
+        "alt_search": "未找到 [SEARCH_TERM] 的相关结果。改为显示 [DIFFERENT_TERM] 的相关结果",
+        "search_suggestion": "未找到 [SEARCH_TERM] 的相关结果。请尝试以下搜索。",
+        "searching": "正在搜索 [SEARCH_TERM]..."
+    }
+}

--- a/pagefind_web/Cargo.toml
+++ b/pagefind_web/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 wasm-bindgen = "0.2"
 bit-set = "0.5"
-pagefind_stem = { version = "0.1.0", features = ["english"] }
+pagefind_stem = "0.2.0"
 minicbor = { version = "0.15.0", features = ["derive"] }
 wee_alloc = "0.4"
 
@@ -17,3 +17,33 @@ wee_alloc = "0.4"
 # Tell `rustc` to optimize for small code size.
 opt-level = "z"
 lto = true
+
+[features]
+ar = ["pagefind_stem/arabic"]
+hy = ["pagefind_stem/armenian"]
+eu = ["pagefind_stem/basque"]
+ca = ["pagefind_stem/catalan"]
+da = ["pagefind_stem/danish"]
+nl = ["pagefind_stem/dutch"]
+en = ["pagefind_stem/english"]
+fi = ["pagefind_stem/finnish"]
+fr = ["pagefind_stem/french"]
+de = ["pagefind_stem/german"]
+el = ["pagefind_stem/greek"]
+hi = ["pagefind_stem/hindi"]
+hu = ["pagefind_stem/hungarian"]
+id = ["pagefind_stem/indonesian"]
+ga = ["pagefind_stem/irish"]
+it = ["pagefind_stem/italian"]
+lt = ["pagefind_stem/lithuanian"]
+ne = ["pagefind_stem/nepali"]
+no = ["pagefind_stem/norwegian"]
+pt = ["pagefind_stem/portuguese"]
+ro = ["pagefind_stem/romanian"]
+ru = ["pagefind_stem/russian"]
+sr = ["pagefind_stem/serbian"]
+es = ["pagefind_stem/spanish"]
+sv = ["pagefind_stem/swedish"]
+ta = ["pagefind_stem/tamil"]
+tr = ["pagefind_stem/turkish"]
+yi = ["pagefind_stem/yiddish"]

--- a/pagefind_web/local_build.sh
+++ b/pagefind_web/local_build.sh
@@ -8,6 +8,12 @@ set -e
 #
 ##
 
+if [[ -z "${GIT_VERSION}" ]]; then
+  WASM_VERSION="0.0.0"
+else
+  WASM_VERSION="${GIT_VERSION}"
+fi
+
 rm ../pagefind/vendor/wasm/* || true
 mkdir -p ../pagefind/vendor/wasm
 
@@ -17,11 +23,11 @@ if [ "$1" = "debug" ]; then
 else
     wasm-pack build --release -t no-modules 
 fi
-mv pkg/pagefind_web.js ../pagefind/vendor/pagefind_web.0.0.0.js
+mv pkg/pagefind_web.js ../pagefind/vendor/pagefind_web.$WASM_VERSION.js
 # Append pagefind_dcd to the decompressed wasm as a magic word read by the frontend
-printf 'pagefind_dcd' > ../pagefind/vendor/wasm/pagefind_web_bg.unknown.0.0.0.wasm
-cat pkg/pagefind_web_bg.wasm >> ../pagefind/vendor/wasm/pagefind_web_bg.unknown.0.0.0.wasm
-gzip --best ../pagefind/vendor/wasm/pagefind_web_bg.unknown.0.0.0.wasm
+printf 'pagefind_dcd' > ../pagefind/vendor/wasm/pagefind_web_bg.unknown.$WASM_VERSION.wasm
+cat pkg/pagefind_web_bg.wasm >> ../pagefind/vendor/wasm/pagefind_web_bg.unknown.$WASM_VERSION.wasm
+gzip --best ../pagefind/vendor/wasm/pagefind_web_bg.unknown.$WASM_VERSION.wasm
 
 # Build the language-specific wasm files,
 # naively grabbing all features from this crate's Cargo.toml
@@ -33,9 +39,9 @@ grep -e pagefind_stem/ Cargo.toml | while read line ; do
     fi
 
     # Append pagefind_dcd to the decompressed wasm as a magic word read by the frontend
-    printf 'pagefind_dcd' > ../pagefind/vendor/wasm/pagefind_web_bg.${line:0:2}.0.0.0.wasm
-    cat pkg/pagefind_web_bg.wasm >> ../pagefind/vendor/wasm/pagefind_web_bg.${line:0:2}.0.0.0.wasm
-    gzip --best ../pagefind/vendor/wasm/pagefind_web_bg.${line:0:2}.0.0.0.wasm
+    printf 'pagefind_dcd' > ../pagefind/vendor/wasm/pagefind_web_bg.${line:0:2}.$WASM_VERSION.wasm
+    cat pkg/pagefind_web_bg.wasm >> ../pagefind/vendor/wasm/pagefind_web_bg.${line:0:2}.$WASM_VERSION.wasm
+    gzip --best ../pagefind/vendor/wasm/pagefind_web_bg.${line:0:2}.$WASM_VERSION.wasm
 done
 
 ls -lh ../pagefind/vendor/wasm/

--- a/pagefind_web/local_build.sh
+++ b/pagefind_web/local_build.sh
@@ -1,13 +1,41 @@
 #!/usr/bin/env bash
+set -e
 
-rm ../pagefind/vendor/pagefind_web*
-if [ $1 = "debug" ]; then
-wasm-pack build --debug -t no-modules
+##
+#
+# TODO: Run the language files through binary diffing (i.e: divvun/bidiff) based on generic
+# so that the main Pagefind CLI doesn't need to include each language wasm in full.
+#
+##
+
+rm ../pagefind/vendor/wasm/* || true
+mkdir -p ../pagefind/vendor/wasm
+
+# Build the generic wasm file
+if [ "$1" = "debug" ]; then
+    wasm-pack build --dev -t no-modules
 else
-wasm-pack build --release -t no-modules
+    wasm-pack build --release -t no-modules 
 fi
-mkdir -p ../pagefind/vendor
-cp pkg/pagefind_web_bg.wasm ../pagefind/vendor/pagefind_web_bg.0.0.0.wasm
-cp pkg/pagefind_web.js ../pagefind/vendor/pagefind_web.0.0.0.js
+mv pkg/pagefind_web.js ../pagefind/vendor/pagefind_web.0.0.0.js
+# Append pagefind_dcd to the decompressed wasm as a magic word read by the frontend
+printf 'pagefind_dcd' > ../pagefind/vendor/wasm/pagefind_web_bg.unknown.0.0.0.wasm
+cat pkg/pagefind_web_bg.wasm >> ../pagefind/vendor/wasm/pagefind_web_bg.unknown.0.0.0.wasm
+gzip --best ../pagefind/vendor/wasm/pagefind_web_bg.unknown.0.0.0.wasm
 
-ls -lh ../pagefind/vendor/
+# Build the language-specific wasm files,
+# naively grabbing all features from this crate's Cargo.toml
+grep -e pagefind_stem/ Cargo.toml | while read line ; do
+    if [ "$1" = "debug" ]; then
+        wasm-pack build --dev -t no-modules --features ${line:0:2}
+    else
+        wasm-pack build --release -t no-modules --features ${line:0:2}
+    fi
+
+    # Append pagefind_dcd to the decompressed wasm as a magic word read by the frontend
+    printf 'pagefind_dcd' > ../pagefind/vendor/wasm/pagefind_web_bg.${line:0:2}.0.0.0.wasm
+    cat pkg/pagefind_web_bg.wasm >> ../pagefind/vendor/wasm/pagefind_web_bg.${line:0:2}.0.0.0.wasm
+    gzip --best ../pagefind/vendor/wasm/pagefind_web_bg.${line:0:2}.0.0.0.wasm
+done
+
+ls -lh ../pagefind/vendor/wasm/

--- a/wrappers/node/lib/download.js
+++ b/wrappers/node/lib/download.js
@@ -224,7 +224,7 @@ function untar(zipPath, destinationDir) {
 }
 
 async function unzipPagefind(zipPath, destinationDir) {
-    const expectedName = path.join(destinationDir, 'pagefind');
+    const expectedName = path.join(destinationDir, 'pagefind_extended');
 
     if (await fsExists(expectedName)) {
         await fsUnlink(expectedName);
@@ -244,7 +244,7 @@ async function unzipPagefind(zipPath, destinationDir) {
         return expectedName + '.exe';
     }
 
-    throw new Error(`Expecting pagefind or pagefind.exe unzipped into ${destinationDir}, didn't find one.`);
+    throw new Error(`Expecting pagefind_extended or pagefind_extended.exe unzipped into ${destinationDir}, didn't find one.`);
 }
 
 async function cleanCache() {
@@ -279,7 +279,7 @@ module.exports = async opts => {
         return Promise.reject(new Error('Missing target'));
     }
 
-    const assetName = ['pagefind', opts.version, opts.target].join('-') + '.tar.gz';
+    const assetName = ['pagefind_extended', opts.version, opts.target].join('-') + '.tar.gz';
 
     if (!await fsExists(tmpDir)) {
         await fsMkdir(tmpDir, { recursive: true });
@@ -293,7 +293,7 @@ module.exports = async opts => {
         console.log('Deleting invalid download cache');
         try {
             await fsUnlink(assetDownloadPath);
-            const expectedName = path.join(opts.destDir, 'pagefind');
+            const expectedName = path.join(opts.destDir, 'pagefind_extended');
 
             if (await fsExists(expectedName)) {
                 await fsUnlink(expectedName);

--- a/wrappers/node/lib/index.js
+++ b/wrappers/node/lib/index.js
@@ -4,7 +4,7 @@ const { execFileSync } = require('child_process');
 
 try {
     execFileSync(
-        path.join(__dirname, `../bin/pagefind${process.platform === 'win32' ? '.exe' : ''}`),
+        path.join(__dirname, `../bin/pagefind_extended${process.platform === 'win32' ? '.exe' : ''}`),
         process.argv.slice(2),
         {
             stdio: [process.stdin, process.stdout, process.stderr]


### PR DESCRIPTION
Tracking PR for multilingual support in the works.

- [x] Stem detected language (if possible) on the search backend
- [x] Split pages into separate meta indexes, with distinct chunks/fragments/etc, based on the `<html lang="...">`
- [x] Build and output distinct webassembly files per language
- [x] Load the appropriate meta index when loaded onto a page with a `<html lang="...">`
- [x] Stem detected language (if possible) on the search frontend
- [x] Render Pagefind UI in the detected language if available
- [x] Audit the whole flow for better logging around detected and unknown languages
- [x] Add configuration option to opt out of multilingual detection altogether
- [x] Walk back some of the normalization to stop collapsing dialects into the same language index files