### PR TITLE
Add sorting options to Pagefind

### DIFF
--- a/docs/content/docs/api.md
+++ b/docs/content/docs/api.md
@@ -144,6 +144,53 @@ If all filters have been loaded with `await pagefind.filters()`, counts will als
 }
 ```
 
+## Sorting results
+
+If pages on your site have been tagged with [sort attributes](/docs/sorts/), a `sort` object can be provided to Pagefind when searching:
+
+{{< diffcode >}}
+```js
+const search = await pagefind.search("static", {
++    sort: {
++        date: "asc"
++    }
+});
+```
+{{< /diffcode >}}
+
+This object should contain one key, matching a `data-pagefind-sort` attribute, and specify either `asc` for ascending or `desc` for descending sort order.
+
+This will override any page relevance sorting, and will return all matching results sorted by the given attribute.
+
+## Filtering without search
+
+If the search term passed to Pagefind is the value `null`, Pagefind will return all results. For example, the following snippet will return all pages in the index, sorted by their date.
+
+{{< diffcode >}}
+```js
+const search = await pagefind.search(null, {
+    sort: {
+        date: "asc"
+    }
+});
+```
+{{< /diffcode >}}
+
+Filters will still be applied, allowing Pagefind to be used as a filtering tool instead of a searching tool:
+
+{{< diffcode >}}
+```js
+const search = await pagefind.search(null, {
+    filters: {
+        category: "Posts"
+    },
+    sort: {
+        date: "asc"
+    }
+});
+```
+{{< /diffcode >}}
+
 ## Preloading search terms
 
 If you have a debounced search input, Pagefind won't start loading indexes until you run your search query. To speed up your search query when it runs, you can use the `pagefind.preload` function as the user is typing. 

--- a/docs/content/docs/sorts.md
+++ b/docs/content/docs/sorts.md
@@ -1,0 +1,45 @@
+---
+date: 2022-06-01
+title: "Custom sort orders"
+nav_title: "Custom sort orders"
+nav_section: Indexing
+weight: 90
+---
+
+For users interacting with the Pagefind JS API directly, Pagefind supports sorting results by tagged attributes instead of page relevancy. For a sort to be available in the browser, pages must be tagged with the `data-pagefind-sort` attribute.
+
+## Sorting pages by tagged elements
+
+```html
+<p data-pagefind-sort="date">2022-10-20</p>
+```
+
+An element tagged with `data-pagefind-sort` will capture the contents of that element and provide the given key as a sort option to the Pagefind JS API.
+
+## Sorting pages by tagged attributes
+
+If your sort value exists as an attribute, you can use the syntax `key[html_attribute]`
+
+```html
+<h1 data-pagefind-sort="weight[data-weight]" data-weight="10">Hello World</h1>
+```
+
+## Sorting pages by tagged values
+
+If your sort value doesn't already exist on the page, you can simply use the syntax `key:value`
+
+```html
+<h1 data-pagefind-sort="date:2022-06-01">Hello World</h1>
+```
+
+## Advanced tagging
+
+The sort syntax follows the same rules as the metadata syntax, see [Defining multiple metadata keys on a single element](/docs/metadata/#defining-multiple-metadata-keys-on-a-single-element) for more detail.
+
+## Notes
+
+> If all values tagged by a given sort key can be parsed as numbers (integers or floats) then Pagefind will sort them numerically. If any values are not parsable, all values will be sorted alphabetically. 
+
+> Pages that omit a `data-pagefind-sort` tag for a given sorting key will be omitted from search results if that sort is applied. i.e. if a site has four pages, and three are tagged `data-pagefind-sort="date"`, sorting your search results by `date` will return three total results.
+
+> Sort orders are precomputed while indexing the site. Due to this, if you are using the [Multisite feature](/docs/multisite/) sorting will not be fully correct. Searching across multiple indexes with a sort applied will first sort each index, and then zip them together, providing interlaced results from each index.

--- a/pagefind/Cargo.toml
+++ b/pagefind/Cargo.toml
@@ -73,6 +73,7 @@ twelf = { version = "0.5", default-features = false, features = [
 portpicker = "0.1"
 actix-web = "4"
 actix-files = "0.6"
+lexical-core = "0.8.5"
 
 [features]
 

--- a/pagefind/features/filtering.feature
+++ b/pagefind/features/filtering.feature
@@ -62,7 +62,6 @@ Feature: Filtering
         Then There should be no logs
         Then The selector "[data-results]" should contain "/ali/, /cheeka/, /theodore/"
 
-
     Scenario: Filter counts are returned for a given search term
         When I evaluate:
             """
@@ -129,6 +128,25 @@ Feature: Filtering
                 let pagefind = await import("/_pagefind/pagefind.js");
 
                 let search = await pagefind.search("Cat", {
+                    filters: {
+                        color: "White"
+                    }
+                });
+                let data = await Promise.all(search.results.map(result => result.data()));
+
+                document.querySelector('[data-results]').innerText = data.map(d => d.url).sort().join(', ');
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-results]" should contain "/cheeka/, /theodore/"
+
+    Scenario: Filtering without search term returns only filter
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/_pagefind/pagefind.js");
+
+                let search = await pagefind.search(null, {
                     filters: {
                         color: "White"
                     }

--- a/pagefind/features/sorting.feature
+++ b/pagefind/features/sorting.feature
@@ -13,6 +13,7 @@ Feature: Result Sorting
             <h1>Robe <i data-pagefind-sort="model">Painte</i> ™️</h1>
             <i data-pagefind-sort="weight:-0.4"></i>
             <b data-pagefind-sort="mixed">1</b>
+            <u data-pagefind-sort="color">black</u>
             """
         Given I have a "public/robe/megapointe/index.html" file with the body:
             """
@@ -20,6 +21,7 @@ Feature: Result Sorting
             <h1>Robe <i data-pagefind-sort="model">MegaPointe</i> ™️</h1>
             <i data-pagefind-sort="weight:9.9"></i>
             <b data-pagefind-sort="mixed">9.5</b>
+            <u data-pagefind-sort="color">white</u>
             """
         Given I have a "public/robe/superspikie/index.html" file with the body:
             """
@@ -108,3 +110,22 @@ Feature: Result Sorting
         Then There should be no logs
         Then The selector "[data-asc]" should contain "/robe/painte/, /robe/megapointe/, /robe/superspikie/"
         Then The selector "[data-desc]" should contain "/robe/superspikie/, /robe/megapointe/, /robe/painte/"
+
+    Scenario: Pagefind excludes pages that aren't tagged with the provided sort option
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/_pagefind/pagefind.js");
+
+                let asc_search = await pagefind.search("Robe", { sort: { color: "asc" } });
+                let asc_data = await Promise.all(asc_search.results.map(result => result.data()));
+                document.querySelector('[data-asc]').innerText = asc_data.map(d => d.url).join(', ');
+
+                let desc_search = await pagefind.search("Robe", { sort: { color: "desc" } });
+                let desc_data = await Promise.all(desc_search.results.map(result => result.data()));
+                document.querySelector('[data-desc]').innerText = desc_data.map(d => d.url).join(', ');
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-asc]" should contain "/robe/painte/, /robe/megapointe/"
+        Then The selector "[data-desc]" should contain "/robe/megapointe/, /robe/painte/"

--- a/pagefind/features/sorting.feature
+++ b/pagefind/features/sorting.feature
@@ -1,0 +1,89 @@
+Feature: Result Sorting
+    Background:
+        Given I have the environment variables:
+            | PAGEFIND_SOURCE | public |
+        Given I have a "public/index.html" file with the body:
+            """
+            <p data-asc></p>
+            <p data-desc></p>
+            """
+        Given I have a "public/robe/painte/index.html" file with the body:
+            """
+            <div data-pagefind-sort="released:April 19th 2022">
+                <span data-lumens="14900" data-pagefind-sort="lumens[data-lumens]"></span>
+                <h1>Robe <i data-pagefind-sort="model">Painte</i> ™️</h1>
+            </div>
+            """
+        Given I have a "public/robe/megapointe/index.html" file with the body:
+            """
+            <p data-pagefind-sort="released">Sept 05 2017</p>
+            <span data-pagefind-sort="lumens">9870</span>
+            <h1>Robe <i data-pagefind-sort="model">MegaPointe</i> ™️</h1>
+            """
+        Given I have a "public/robe/superspikie/index.html" file with the body:
+            """
+            <p data-pagefind-sort="released">2018/10/16</p>
+            <span data-pagefind-sort="lumens">5105</span>
+            <h1>Robe <i data-pagefind-sort="model">SuperSpikie</i> ™️</h1>
+            """
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        When I serve the "public" directory
+        When I load "/"
+
+    Scenario: Pagefind can sort results by an ascending alphabetical attribute
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/_pagefind/pagefind.js");
+
+                let asc_search = await pagefind.search("Robe", { sort: { model: "asc" } });
+                let asc_data = await Promise.all(asc_search.results.map(result => result.data()));
+                document.querySelector('[data-asc]').innerText = asc_data.map(d => d.url).join(', ');
+
+                let desc_search = await pagefind.search("Robe", { sort: { model: "desc" } });
+                let desc_data = await Promise.all(desc_search.results.map(result => result.data()));
+                document.querySelector('[data-desc]').innerText = desc_data.map(d => d.url).join(', ');
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-asc]" should contain "/robe/megapointe/, /robe/painte/, /robe/superspikie/"
+        Then The selector "[data-desc]" should contain "/robe/superspikie/, /robe/painte/, /robe/megapointe/"
+
+    Scenario: Pagefind can sort results by an automatically detected integer
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/_pagefind/pagefind.js");
+
+                let asc_search = await pagefind.search("Robe", { sort: { lumens: "asc" } });
+                let asc_data = await Promise.all(asc_search.results.map(result => result.data()));
+                document.querySelector('[data-asc]').innerText = asc_data.map(d => d.url).join(', ');
+
+                let desc_search = await pagefind.search("Robe", { sort: { lumens: "desc" } });
+                let desc_data = await Promise.all(desc_search.results.map(result => result.data()));
+                document.querySelector('[data-desc]').innerText = desc_data.map(d => d.url).join(', ');
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-asc]" should contain "/robe/superspikie/, /robe/megapointe/, /robe/painte/"
+        Then The selector "[data-desc]" should contain "/robe/painte/, /robe/megapointe/, /robe/superspikie/"
+
+    Scenario: Pagefind can sort results by an automatically detected date string
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/_pagefind/pagefind.js");
+
+                let asc_search = await pagefind.search("Robe", { sort: { released: "asc" } });
+                let asc_data = await Promise.all(asc_search.results.map(result => result.data()));
+                document.querySelector('[data-asc]').innerText = asc_data.map(d => d.url).join(', ');
+
+                let desc_search = await pagefind.search("Robe", { sort: { released: "desc" } });
+                let desc_data = await Promise.all(desc_search.results.map(result => result.data()));
+                document.querySelector('[data-desc]').innerText = desc_data.map(d => d.url).join(', ');
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-asc]" should contain "/robe/megapointe/, /robe/superspikie/, /robe/painte/"
+        Then The selector "[data-desc]" should contain "/robe/painte/, /robe/superspikie/, /robe/megapointe/"

--- a/pagefind/features/sorting.feature
+++ b/pagefind/features/sorting.feature
@@ -9,29 +9,31 @@ Feature: Result Sorting
             """
         Given I have a "public/robe/painte/index.html" file with the body:
             """
-            <div data-pagefind-sort="released:April 19th 2022">
-                <span data-lumens="14900" data-pagefind-sort="lumens[data-lumens]"></span>
-                <h1>Robe <i data-pagefind-sort="model">Painte</i> ™️</h1>
-            </div>
+            <span data-lumens="14900" data-pagefind-sort="lumens[data-lumens]"></span>
+            <h1>Robe <i data-pagefind-sort="model">Painte</i> ™️</h1>
+            <i data-pagefind-sort="weight:-0.4"></i>
+            <b data-pagefind-sort="mixed">1</b>
             """
         Given I have a "public/robe/megapointe/index.html" file with the body:
             """
-            <p data-pagefind-sort="released">Sept 05 2017</p>
-            <span data-pagefind-sort="lumens">9870</span>
+            <span data-pagefind-sort="lumens:9870"></span>
             <h1>Robe <i data-pagefind-sort="model">MegaPointe</i> ™️</h1>
+            <i data-pagefind-sort="weight:9.9"></i>
+            <b data-pagefind-sort="mixed">9.5</b>
             """
         Given I have a "public/robe/superspikie/index.html" file with the body:
             """
-            <p data-pagefind-sort="released">2018/10/16</p>
             <span data-pagefind-sort="lumens">5105</span>
             <h1>Robe <i data-pagefind-sort="model">SuperSpikie</i> ™️</h1>
+            <i data-pagefind-sort="weight:1234.5678"></i>
+            <b data-pagefind-sort="mixed">10</b>
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
         When I serve the "public" directory
         When I load "/"
 
-    Scenario: Pagefind can sort results by an ascending alphabetical attribute
+    Scenario: Pagefind can sort results by an alphabetical attribute
         When I evaluate:
             """
             async function() {
@@ -69,21 +71,40 @@ Feature: Result Sorting
         Then The selector "[data-asc]" should contain "/robe/superspikie/, /robe/megapointe/, /robe/painte/"
         Then The selector "[data-desc]" should contain "/robe/painte/, /robe/megapointe/, /robe/superspikie/"
 
-    Scenario: Pagefind can sort results by an automatically detected date string
+    Scenario: Pagefind can sort results by an automatically detected float
         When I evaluate:
             """
             async function() {
                 let pagefind = await import("/_pagefind/pagefind.js");
 
-                let asc_search = await pagefind.search("Robe", { sort: { released: "asc" } });
+                let asc_search = await pagefind.search("Robe", { sort: { weight: "asc" } });
                 let asc_data = await Promise.all(asc_search.results.map(result => result.data()));
                 document.querySelector('[data-asc]').innerText = asc_data.map(d => d.url).join(', ');
 
-                let desc_search = await pagefind.search("Robe", { sort: { released: "desc" } });
+                let desc_search = await pagefind.search("Robe", { sort: { weight: "desc" } });
                 let desc_data = await Promise.all(desc_search.results.map(result => result.data()));
                 document.querySelector('[data-desc]').innerText = desc_data.map(d => d.url).join(', ');
             }
             """
         Then There should be no logs
-        Then The selector "[data-asc]" should contain "/robe/megapointe/, /robe/superspikie/, /robe/painte/"
-        Then The selector "[data-desc]" should contain "/robe/painte/, /robe/superspikie/, /robe/megapointe/"
+        Then The selector "[data-asc]" should contain "/robe/painte/, /robe/megapointe/, /robe/superspikie/"
+        Then The selector "[data-desc]" should contain "/robe/superspikie/, /robe/megapointe/, /robe/painte/"
+
+    Scenario: Pagefind can sort results by mixed floats and integers
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/_pagefind/pagefind.js");
+
+                let asc_search = await pagefind.search("Robe", { sort: { mixed: "asc" } });
+                let asc_data = await Promise.all(asc_search.results.map(result => result.data()));
+                document.querySelector('[data-asc]').innerText = asc_data.map(d => d.url).join(', ');
+
+                let desc_search = await pagefind.search("Robe", { sort: { mixed: "desc" } });
+                let desc_data = await Promise.all(desc_search.results.map(result => result.data()));
+                document.querySelector('[data-desc]').innerText = desc_data.map(d => d.url).join(', ');
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-asc]" should contain "/robe/painte/, /robe/megapointe/, /robe/superspikie/"
+        Then The selector "[data-desc]" should contain "/robe/superspikie/, /robe/megapointe/, /robe/painte/"

--- a/pagefind/src/fossick/mod.rs
+++ b/pagefind/src/fossick/mod.rs
@@ -28,6 +28,7 @@ pub struct FossickedData {
     pub file_path: PathBuf,
     pub fragment: PageFragment,
     pub word_data: HashMap<String, Vec<u32>>,
+    pub sort: HashMap<String, String>,
     pub has_custom_body: bool,
     pub has_html_element: bool,
     pub language: String,
@@ -165,7 +166,7 @@ impl Fossicker {
             has_html_element: data.has_html_element,
             language: data.language,
             fragment: PageFragment {
-                page_number: 0,
+                page_number: 0, // This page number is updated later once determined
                 data: PageFragmentData {
                     url,
                     content,
@@ -175,6 +176,7 @@ impl Fossicker {
                 },
             },
             word_data,
+            sort: data.sort,
         })
     }
 }

--- a/pagefind/src/index/index_metadata.rs
+++ b/pagefind/src/index/index_metadata.rs
@@ -3,7 +3,7 @@ use minicbor::Encode;
 /// The pagefind.pf_meta file loaded on init
 
 /// All metadata we need to glue together search queries & results
-#[derive(Encode)]
+#[derive(Encode, Debug)]
 pub struct MetaIndex {
     #[n(0)]
     pub version: String,
@@ -13,6 +13,8 @@ pub struct MetaIndex {
     pub index_chunks: Vec<MetaChunk>,
     #[n(3)]
     pub filters: Vec<MetaFilter>,
+    #[n(4)]
+    pub sorts: Vec<MetaSort>,
 }
 
 /// Communicates the _pagefind/index/*.pf_index file we need to load
@@ -27,7 +29,7 @@ pub struct MetaChunk {
     pub hash: String,
 }
 
-#[derive(Encode)]
+#[derive(Encode, Debug)]
 pub struct MetaPage {
     #[n(0)]
     pub hash: String,
@@ -35,10 +37,18 @@ pub struct MetaPage {
     pub word_count: u32,
 }
 
-#[derive(Encode)]
+#[derive(Encode, Debug)]
 pub struct MetaFilter {
     #[n(0)]
     pub filter: String,
     #[n(1)]
     pub hash: String,
+}
+
+#[derive(Encode, Debug)]
+pub struct MetaSort {
+    #[n(0)]
+    pub sort: String,
+    #[n(1)]
+    pub pages: Vec<usize>,
 }

--- a/pagefind/src/output/stubs/search.js
+++ b/pagefind/src/output/stubs/search.js
@@ -303,6 +303,8 @@ class PagefindInstance {
         log(`Starting search on ${this.basePath}`);
         let start = Date.now();
         let ptr = await this.getPtr();
+        let filter_only = term === null;
+        term = term ?? "";
         let exact_search = /^\s*".+"\s*$/.test(term);
         if (exact_search) {
             log(`Running an exact search`);
@@ -312,7 +314,7 @@ class PagefindInstance {
         term = term.toLowerCase().trim().replace(/[\.`~!@#\$%\^&\*\(\)\{\}\[\]\\\|:;'",<>\/\?\-]/g, "").replace(/\s{2,}/g, " ").trim();
         log(`Normalized search term to ${term}`);
 
-        if (!term?.length) {
+        if (!term?.length && !filter_only) {
             return {
                 results: [],
                 filters: {},

--- a/pagefind/src/output/stubs/search.js
+++ b/pagefind/src/output/stubs/search.js
@@ -275,6 +275,23 @@ class PagefindInstance {
         return filter_list.join("__PF_FILTER_DELIM__");
     }
 
+    stringifySorts(obj = {}) {
+        let sorts = Object.entries(obj);
+        // We currently only support one sort directive,
+        // so we'll grab the first sort provided in the object.
+        for (let [sort, direction] of sorts) {
+            if (sorts.length > 1) {
+                console.warn(`Pagefind was provided multiple sort options in this search, but can only operate on one. Using the ${sort} sort.`);
+            }
+            if (direction !== "asc" && direction !== "desc") {
+                console.warn(`Pagefind was provided a sort with unknown direction ${direction}. Supported: [asc, desc]`);
+            }
+            return `${sort}:${direction}`;
+        }
+
+        return ``;
+    }
+
     async filters() {
         let ptr = await this.getPtr();
 
@@ -297,6 +314,7 @@ class PagefindInstance {
         options = {
             verbose: false,
             filters: {},
+            sort: {},
             ...options,
         };
         const log = str => { if (options.verbose) console.log(str) };
@@ -326,6 +344,9 @@ class PagefindInstance {
             };
         }
 
+        let sort_list = this.stringifySorts(options.sort);
+        log(`Stringified sort to ${sort_list}`);
+
         const filter_list = this.stringifyFilters(options.filters);
         log(`Stringified filters to ${filter_list}`);
 
@@ -342,7 +363,7 @@ class PagefindInstance {
         // pointer may have updated from the loadChunk calls
         ptr = await this.getPtr();
         let searchStart = Date.now();
-        let result = this.backend.search(ptr, term, filter_list, exact_search);
+        let result = this.backend.search(ptr, term, filter_list, sort_list, exact_search);
         log(`Got the raw search result: ${result}`);
         let [results, filters] = result.split(/:(.*)$/);
         let filterObj = this.parseFilters(filters);


### PR DESCRIPTION
Allows search or filter results to be sorted by tagged attributes instead of the default relevancy sort. Also adds the ability to filter the index without providing a search term.