### PR TITLE
Improve a11y by reverting outline default styles

### DIFF
--- a/pagefind_ui/svelte/reset.svelte
+++ b/pagefind_ui/svelte/reset.svelte
@@ -15,6 +15,7 @@
                     *, symbol *))) {
         all: unset;
         display: revert;
+        outline: revert;
     }
 
     /* Preferred box-sizing value */


### PR DESCRIPTION
Closes https://github.com/CloudCannon/pagefind/issues/159