### PR TITLE
Skip user's profile when invoking powershell

### DIFF
--- a/wrappers/node/lib/download.js
+++ b/wrappers/node/lib/download.js
@@ -52,7 +52,7 @@ function downloadWin(url, dest, opts) {
             }
         }
 
-        iwrCmd = `powershell "${iwrCmd}"`;
+        iwrCmd = `powershell -noprofile "${iwrCmd}"`;
 
         child_process.exec(iwrCmd, err => {
             if (err) {


### PR DESCRIPTION
Pagefind fails for me unless I comment out my powershell profile. Adding this flag should fix this.

(I was unable to get pagefind running even after cloning my fork. The instructions in CONTRIBUTING.md did not work for me.)