### PR TITLE
Adding flag to retain “index.html” in results URLs

### DIFF
--- a/docs/content/docs/search-config.md
+++ b/docs/content/docs/search-config.md
@@ -63,6 +63,16 @@ Overrides the bundle directory. In most cases this should be automatically detec
 
 See [multisite search > weighting](/docs/multisite/#changing-the-weighting-of-individual-indexes)
 
+### Keep Index URL
+
+```json
+{
+    "keepIndexUrl": true
+}
+```
+
+Keeps `index.html` at the end of search result paths. For example, a file called "public/cat/index.html will have a search result url of `public/cat/index.html`. Defaults to `false`, stripping `index.html`.
+
 ### Merge filter
 
 See [multisite search > filtering](/docs/multisite/#filtering-results-by-index)

--- a/pagefind/features/search_options.feature
+++ b/pagefind/features/search_options.feature
@@ -63,3 +63,33 @@ Feature: Search Options
             """
         Then There should be no logs
         Then The selector "[data-url]" should contain "/blog/cat/"
+
+    Scenario: Keep Index URL can be configured
+        Given I have a "public/index.html" file with the body:
+            """
+            <p data-url>Nothing</p>
+            """
+        Given I have a "public/cat/index.html" file with the body:
+            """
+            <h1>world</h1>
+            """
+        When I run my program with the flags:
+            | --bundle-dir blog/_pagefind |
+            | --keep-index-url |
+        Then I should see "Running Pagefind" in stdout
+        Then I should see the file "public/blog/_pagefind/pagefind.js"
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/blog/_pagefind/pagefind.js");
+
+                let search = await pagefind.search("world");
+
+                let data = await search.results[0].data();
+                document.querySelector('[data-url]').innerText = data.url;
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-url]" should contain "/blog/cat/index.html"

--- a/pagefind/src/fossick/mod.rs
+++ b/pagefind/src/fossick/mod.rs
@@ -219,9 +219,15 @@ fn build_url(page_url: &Path, options: &SearchOptions) -> String {
         return "/unknown/".to_string();
     };
 
+    let final_url: String = if !options.keep_index_url {
+        url.to_slash_lossy().to_owned().replace("index.html", "")
+    } else {
+        url.to_slash_lossy().to_owned().to_string()
+    };
+
     format!(
         "/{}",
-        url.to_slash_lossy().to_owned().replace("index.html", "")
+        final_url
     )
 }
 

--- a/pagefind/src/options.rs
+++ b/pagefind/src/options.rs
@@ -70,6 +70,15 @@ pub struct PagefindInboundConfig {
     #[clap(required = false)]
     #[serde(default = "defaults::default_false")]
     pub verbose: bool,
+
+    #[clap(
+        long,
+        short,
+        help = "Keep \"index.html\" at the end of search result paths. Defaults to false, stripping \"index.html\"."
+    )]
+    #[clap(required = false)]
+    #[serde(default = "defaults::default_false")]
+    pub keep_index_url: bool,
 }
 
 mod defaults {
@@ -99,6 +108,7 @@ pub struct SearchOptions {
     pub force_language: Option<String>,
     pub version: &'static str,
     pub logger: Logger,
+    pub keep_index_url: bool
 }
 
 impl SearchOptions {
@@ -124,6 +134,7 @@ impl SearchOptions {
                 force_language: config.force_language,
                 version: env!("CARGO_PKG_VERSION"),
                 logger: Logger::new(log_level),
+                keep_index_url: config.keep_index_url
             })
         }
     }


### PR DESCRIPTION
# What
* Add a new CLI flag to retain “index.html” in search result links
* Added a test case for this flag
* Added documentation with usage

# Why
My static site does not use “pretty” links. The current Pagefund behavior generates search result links that do not accurately link to my content. This change makes the links compatible.

# Testing
I tested this manually locally. I also added a simple test for this flag. Any ideas for additional test cases are welcome.