### PR TITLE
If a word is not in the index, find the longest matching prefix that is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Added anchor data to the fragments loaded for search results
 * Added `data-pagefind-weight` tag to rank certain content higher
 * Automatically treat `h1` through `h6` tags as a higher weight than body content
+* Tweak partial word matching by returning the prefix of a search word if otherwise not found
 
 ## v0.12.0 (March 1, 2023)
 

--- a/pagefind/features/multilingual.feature
+++ b/pagefind/features/multilingual.feature
@@ -249,7 +249,7 @@ Feature: Multilingual
                     <title>Document</title>
                 </head>
                 <body>
-                    <p>I am a mystery document</p>
+                    <p>I am a documentation</p>
                 </body>
             </html>
             """
@@ -266,7 +266,7 @@ Feature: Multilingual
             async function() {
                 let pagefind = await import("/_pagefind/pagefind.js");
 
-                let search = await pagefind.search("document");
+                let search = await pagefind.search("documentation");
                 let stem_search = await pagefind.search("documenting");
 
                 let data = search.results[0] ? await search.results[0].data() : "None";

--- a/pagefind_web/src/lib.rs
+++ b/pagefind_web/src/lib.rs
@@ -141,10 +141,13 @@ fn try_request_indexes(ptr: *mut SearchIndex, query: &str, load_all_possible: bo
     for term in terms {
         let term_index = search_index.chunks.iter().find(|chunk| {
             if load_all_possible {
-                // Trim chunk boundaries down to the length of the search term
-                // so that we load any chunk that may contain an extension of the search term
-                term >= &chunk.from.chars().take(term.len()).collect::<String>()
-                    && term <= &chunk.to.chars().take(term.len()).collect::<String>()
+                // Trim chunk boundaries and search terms to the shortest of either,
+                // so that we load any chunk that may contain an extension or prefix of the search term
+                let from_length = term.len().min(chunk.from.len());
+                let to_length = term.len().min(chunk.to.len());
+
+                term[0..from_length] >= chunk.from[0..from_length]
+                    && term[0..to_length] <= chunk.to[0..to_length]
             } else {
                 term >= &chunk.from && term <= &chunk.to
             }

--- a/pagefind_web/src/search.rs
+++ b/pagefind_web/src/search.rs
@@ -117,7 +117,7 @@ impl SearchIndex {
 
         let mut unfiltered_results: Vec<usize> = vec![];
         let mut maps = Vec::new();
-        let mut unique_maps = Vec::new();
+        let mut length_maps = Vec::new();
         let mut words = Vec::new();
         let split_term = stems_from_term(term);
 
@@ -129,7 +129,9 @@ impl SearchIndex {
                 for page in word_index {
                     set.insert(page.page as usize);
                 }
-                unique_maps.push((word.len().abs_diff(term.len()) + 1, set.clone()));
+                // Track how far off the matched word our search word was,
+                // to help ranking results later.
+                length_maps.push((word.len().abs_diff(term.len()) + 1, set.clone()));
                 word_maps.push(set);
             }
             if let Some(result) = union_maps(word_maps) {
@@ -186,7 +188,7 @@ impl SearchIndex {
 
             let page = &self.pages[page_index];
             let mut page_score = word_locations.len() as f32 / page.word_count as f32;
-            for (len, map) in unique_maps.iter() {
+            for (len, map) in length_maps.iter() {
                 // Boost pages that match shorter words, as they are closer
                 // to the term that was searched. Combine the weight with
                 // a word frequency to boost high quality results.


### PR DESCRIPTION
A solution for #291 — if a search term cannot be found Pagefind will substitute a prefix of the word.

As an example, the phrase `a doc about installation` will be indexed as the words:

- `a`
- `doc`
- `about`
- `instal`

Where `installation` was stemmed to the root word `instal`. The issue with this is that when a user is typing a query, and has reached `installa`, the stemming library does not recognize it and doesn't also stem it to `instal`. As such, Pagefind looks for `installa` in the index and cannot find it.

This PR adds backtracking logic to this flow, so upon seeing that `installa` has no hits, Pagefind will continue with a search for `instal` as the longest matching prefix that *is* in the index.

This does have some side effects. In the example above, searching for `document` or `docker` will return results for `doc` if there aren't better matches. Or searching for `artery` will return results for `a`. Overall I don't see this as a massive concern, as if there are multiple results these should be lower, due to the matched word being different in length to the search term. In most cases where this would impact results, there would have previously been no results.

This also helps to add _some level_ of typo tolerance, though certainly not enough to claim as such. But in our topmost example, currently if you mistyped `installattion` there would be no results, and after this PR it would still be stripped back to `instal` and matched. (If your typo resides in the `instal` prefix, no such luck).

All in all, this looks to solve more issues than it creates, and is a decent approach to this without increasing the bandwidth footprint of Pagefind's index. 