### PR TITLE
feat: allow directly passing `HTMLElement` to default pagefind ui `options.element`

### DIFF
--- a/pagefind_ui/default/ui-core.js
+++ b/pagefind_ui/default/ui-core.js
@@ -37,7 +37,7 @@ export class PagefindUI {
         delete opts["mergeIndex"];
         delete opts["translations"];
 
-        const dom = document.querySelector(selector);
+        const dom = selector instanceof HTMLElement ? selector : document.querySelector(selector);
         if (dom) {
             this._pfs = new PagefindSvelte({
                 target: dom,


### PR DESCRIPTION
closes #330