### PR TITLE
Delete <script type> attribute

### DIFF
--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -14,7 +14,7 @@ Pagefind provides a prebuilt search UI out of the box. Add the following snippet
 
 ```html
 <link href="/_pagefind/pagefind-ui.css" rel="stylesheet">
-<script src="/_pagefind/pagefind-ui.js" type="text/javascript"></script>
+<script src="/_pagefind/pagefind-ui.js"></script>
 <div id="search"></div>
 <script>
     window.addEventListener('DOMContentLoaded', (event) => {

--- a/docs/content/docs/ui.md
+++ b/docs/content/docs/ui.md
@@ -14,7 +14,7 @@ Pagefind UI can be added to any page with the following snippet. The `/_pagefind
 
 ```html
 <link href="/_pagefind/pagefind-ui.css" rel="stylesheet">
-<script src="/_pagefind/pagefind-ui.js" type="text/javascript"></script>
+<script src="/_pagefind/pagefind-ui.js"></script>
 
 <div id="search"></div>
 <script>

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -41,7 +41,7 @@
     {{ partial "banner.html" }}
     {{ partial "nav.html" }}
     <div class="search">
-        <script src="/_pagefind/pagefind-ui.js" type="text/javascript"></script>
+        <script src="/_pagefind/pagefind-ui.js"></script>
         <div id="search"></div>
     </div>
     <div class="column">
@@ -66,6 +66,6 @@
     </script>
 
     {{ $js := resources.Get "js/site.js" | js.Build }}
-    <script type="text/javascript" src="{{ $js.RelPermalink }}" defer></script>
+    <script src="{{ $js.RelPermalink }}" defer></script>
 </body>
 </html>

--- a/pagefind/features/modular_ui/modular_ui_base.feature
+++ b/pagefind/features/modular_ui/modular_ui_base.feature
@@ -7,7 +7,7 @@ Feature: Base Modular UI Tests
             <div id="search"></div>
             <div id="summary"></div>
             <div id="results"></div>
-            <script src="/_pagefind/pagefind-modular-ui.js" type="text/javascript"></script>
+            <script src="/_pagefind/pagefind-modular-ui.js"></script>
 
             <script>
                 window.pagefind = new PagefindModularUI.Instance();

--- a/pagefind/features/multisite/multisite_base.feature
+++ b/pagefind/features/multisite/multisite_base.feature
@@ -44,7 +44,7 @@ Feature: Multisite Search
         Given I have a "root/index.html" file with the body:
             """
             <div id="search"></div>
-            <script src="/website_a/_pagefind/pagefind-ui.js" type="text/javascript"></script>
+            <script src="/website_a/_pagefind/pagefind-ui.js"></script>
             """
         When I run my program with the flags:
             | --source root/website_a |
@@ -107,7 +107,7 @@ Feature: Multisite Search
         Given I have a "root/index.html" file with the body:
             """
             <div id="search"></div>
-            <script src="/website_a/_pagefind/pagefind-ui.js" type="text/javascript"></script>
+            <script src="/website_a/_pagefind/pagefind-ui.js"></script>
             """
         When I run my program with the flags:
             | --source root/website_a |

--- a/pagefind/features/ui/ui_base.feature
+++ b/pagefind/features/ui/ui_base.feature
@@ -5,7 +5,7 @@ Feature: Base UI Tests
         Given I have a "public/index.html" file with the body:
             """
             <div id="search"></div>
-            <script src="/_pagefind/pagefind-ui.js" type="text/javascript"></script>
+            <script src="/_pagefind/pagefind-ui.js"></script>
 
             <script>
                 window.pui = new PagefindUI({ element: "#search" });

--- a/pagefind/features/ui/ui_hooks.feature
+++ b/pagefind/features/ui/ui_hooks.feature
@@ -8,7 +8,7 @@ Feature: UI Hooks
             """
             <h1>Search</h1>
             <div id="search"></div>
-            <script src="/_pagefind/pagefind-ui.js" type="text/javascript"></script>
+            <script src="/_pagefind/pagefind-ui.js"></script>
 
             <script>
                 window.pui = new PagefindUI({
@@ -43,7 +43,7 @@ Feature: UI Hooks
             <h1>Search</h1>
             <img src="my.png" />
             <div id="search"></div>
-            <script src="/_pagefind/pagefind-ui.js" type="text/javascript"></script>
+            <script src="/_pagefind/pagefind-ui.js"></script>
 
             <script>
                 window.pui = new PagefindUI({

--- a/pagefind/features/ui/ui_strings.feature
+++ b/pagefind/features/ui/ui_strings.feature
@@ -12,7 +12,7 @@ Feature: UI Test Strings
                 <body>
                     <h1>Search</h1>
                     <div id="search"></div>
-                    <script src="/_pagefind/pagefind-ui.js" type="text/javascript"></script>
+                    <script src="/_pagefind/pagefind-ui.js"></script>
 
                     <script>
                         window.pui = new PagefindUI({ element: "#search" });
@@ -44,7 +44,7 @@ Feature: UI Test Strings
                 <body>
                     <h1>Search</h1>
                     <div id="search"></div>
-                    <script src="/_pagefind/pagefind-ui.js" type="text/javascript"></script>
+                    <script src="/_pagefind/pagefind-ui.js"></script>
 
                     <script>
                         window.pui = new PagefindUI({

--- a/pagefind_ui/default/_dev_files/index.html
+++ b/pagefind_ui/default/_dev_files/index.html
@@ -12,7 +12,7 @@
     <h1>Hello World from the local dev suite</h1>
     <p>Searches for words ending in <kbd>y</kbd> will return no results</p>
     <div id="search"></div>
-    <script src="/_pagefind/ui.js" type="application/javascript"></script>
+    <script src="/_pagefind/ui.js"></script>
     <script>
         new PagefindUI({ element: "#search" });
     </script>

--- a/pagefind_ui/modular/README.md
+++ b/pagefind_ui/modular/README.md
@@ -19,7 +19,7 @@ The Pagefind CLI outputs assets for the Modular UI that can be loaded directly:
 
 ```html
 <link href="/_pagefind/pagefind-modular-ui.css" rel="stylesheet">
-<script src="/_pagefind/pagefind-modular-ui.js" type="text/javascript"></script>
+<script src="/_pagefind/pagefind-modular-ui.js"></script>
 
 <script>
     window.addEventListener('DOMContentLoaded', (event) => {

--- a/pagefind_ui/modular/_dev_files/index.html
+++ b/pagefind_ui/modular/_dev_files/index.html
@@ -21,7 +21,7 @@
     </pre>
     <h2>Later on, we have some results:</h2>
     <div id="resultlist"></div>
-    <script src="/_pagefind/modular.js" type="application/javascript"></script>
+    <script src="/_pagefind/modular.js"></script>
     <script>
         const pagefind = new PagefindModularUI.Instance();
         pagefind.add(new PagefindModularUI.Input({


### PR DESCRIPTION
This deletes the `type="text/javascript"` and `type="application/javascript"` attributes from the `<script>` elements.

They are redundant as the default script type is JavaScript.

The [HTML standard says](https://html.spec.whatwg.org/multipage/scripting.html#attr-script-type):

> Authors should omit the `type` attribute instead of redundantly setting it.