### PR TITLE
Improve search input on mobile

### DIFF
--- a/pagefind_ui/default/svelte/ui.svelte
+++ b/pagefind_ui/default/svelte/ui.svelte
@@ -204,6 +204,8 @@
             bind:this={input_el}
             type="text"
             placeholder={translate("placeholder")}
+            autocapitalize="none"
+            enterkeyhint="search"
         />
 
         <button

--- a/pagefind_ui/modular/components/input.js
+++ b/pagefind_ui/modular/components/input.js
@@ -87,7 +87,13 @@ export class Input {
                 "data-pfmod-sr-hidden": "true"
             }).text("Search this site").addTo(wrapper)
 
-            this.inputEl = new El("input").id(`pfmod-input-${id}`).class("pagefind-modular-input").addTo(wrapper);
+            this.inputEl = new El("input").id(`pfmod-input-${id}`)
+                .class("pagefind-modular-input")
+                .attrs({
+                    autocapitalize: "none",
+                    enterkeyhint: "search"
+                })
+                .addTo(wrapper);
 
             this.clearEl = new El("button")
                 .class("pagefind-modular-input-clear")


### PR DESCRIPTION
This does two things to optimize the search input on mobile browsers:
- Disables the autocapitalization of the first letter as that does not make sense for search terms.
- Shows the Search icon/label on the mobile keyboard instead of the Go icon/label.

Before:
<img src="https://github.com/CloudCannon/pagefind/assets/5496284/b427c468-6270-4ace-88b0-e5655bb811ce" width="270" height="269" alt="Screenshot of Android keyboard. Capitalization is turned on and the Enter key has an arrow icon." />

After:
<img src="https://github.com/CloudCannon/pagefind/assets/5496284/63331d85-6bc7-420e-91ea-50c9a9864d65" width="270" height="269" alt="Screenshot of Android keyboard. Capitalization is turned off and the Enter key has a search icon." />