### PR TITLE
Return top-level text alongside page anchors in fragments

### DIFF
--- a/pagefind/features/anchors.feature
+++ b/pagefind/features/anchors.feature
@@ -52,7 +52,7 @@ Feature: Anchors
             }
             """
         Then There should be no logs
-        Then The selector "[data-search]" should contain "0, 10"
+        Then The selector "[data-search]" should contain "0, 9"
 
     Scenario: Pagefind returns full content without anchors
         When I evaluate:
@@ -80,7 +80,7 @@ Feature: Anchors
             }
             """
         Then There should be no logs
-        Then The selector "[data-search]" should contain "h2#cats: 4, ul#list: 5, li#ali: 6, h2#pagefind: 9"
+        Then The selector "[data-search]" should contain "h2#cats: 3, ul#list: 4, li#ali: 5, h2#pagefind: 8"
 
     Scenario: Pagefind returns page anchor content in the fragment
         When I evaluate:

--- a/pagefind/features/anchors.feature
+++ b/pagefind/features/anchors.feature
@@ -5,25 +5,35 @@ Feature: Anchors
             | PAGEFIND_SOURCE | public |
         Given I have a "public/index.html" file with the body:
             """
-            <p data-search-one>Nothing</p>
-            <p data-search-two>Nothing</p>
+            <p data-search>Nothing</p>
             """
         Given I have a "public/cat/index.html" file with the body:
             """
             <h1 id="outer-heading">Outer Heading</h1>
             <div data-pagefind-body>
-                <p>Hello World, from Pagefind</p>
+                <p>PageOne, from Pagefind</p>
                 <h2 id="cats">Cats</h2>
-                <ul>
+                <ul id="list">
                     <li>Cheeka</li>
                     <li id="ali">Ali</li>
                     <li>Theodore</li>
                     <li>Smudge</li>
                 </ul>
                 <h2 id="pagefind">Pagefind</h2>
-                <p>Hello World, again, from Pagefind</p>
+                <p>PageOne, again, from Pagefind</p>
             </div>
             <p id="outer-content">Outer Content</p>
+            """
+        Given I have a "public/dog/index.html" file with the body:
+            """
+            <div data-pagefind-body>
+                <h1 id="h1">PageTwo, from Pagefind</h1>
+                <p id="p_spans">Words <span>in</span> <span><span>spans</span></span> should be extracted</p>
+                <h2 id="h2_hrefs">Links <a href="/">should be extracted</a></h2>
+                <span id="span_formatted">Text that is <b>bold</b> or <i>italic</i> should be extracted</span>
+                <p id="p_nested_ids">Text containing <span id="span_nested">nested IDs</span> should extract both</p>
+                <div id="double_div">Divs containing <div>💀 he he he 💀</div> divs should only take from the top level</div>
+            </div>
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
@@ -36,13 +46,13 @@ Feature: Anchors
             async function() {
                 let pagefind = await import("/_pagefind/pagefind.js");
 
-                let searchone = await pagefind.search("hello");
-                let searchonedata = await searchone.results[0].data();
-                document.querySelector('[data-search-one]').innerText = searchonedata.locations.join(', ');
+                let search = await pagefind.search("pageone");
+                let searchdata = await search.results[0].data();
+                document.querySelector('[data-search]').innerText = searchdata.locations.join(', ');
             }
             """
         Then There should be no logs
-        Then The selector "[data-search-one]" should contain "0, 10"
+        Then The selector "[data-search]" should contain "0, 10"
 
     Scenario: Pagefind returns full content without anchors
         When I evaluate:
@@ -50,13 +60,13 @@ Feature: Anchors
             async function() {
                 let pagefind = await import("/_pagefind/pagefind.js");
 
-                let searchone = await pagefind.search("hello");
-                let searchonedata = await searchone.results[0].data();
-                document.querySelector('[data-search-one]').innerText = searchonedata.content;
+                let search = await pagefind.search("pageone");
+                let searchdata = await search.results[0].data();
+                document.querySelector('[data-search]').innerText = searchdata.content;
             }
             """
         Then There should be no logs
-        Then The selector "[data-search-one]" should contain "Hello World, from Pagefind. Cats. Cheeka. Ali. Theodore. Smudge. Pagefind. Hello World, again, from Pagefind."
+        Then The selector "[data-search]" should contain "PageOne, from Pagefind. Cats. Cheeka. Ali. Theodore. Smudge. Pagefind. PageOne, again, from Pagefind."
 
     Scenario: Pagefind returns all page anchors in the fragment
         When I evaluate:
@@ -64,10 +74,48 @@ Feature: Anchors
             async function() {
                 let pagefind = await import("/_pagefind/pagefind.js");
 
-                let searchone = await pagefind.search("hello");
-                let searchonedata = await searchone.results[0].data();
-                document.querySelector('[data-search-one]').innerText = searchonedata.anchors.map(a => `${a.element}#${a.id}: ${a.location}`).join(', ');
+                let search = await pagefind.search("pageone");
+                let searchdata = await search.results[0].data();
+                document.querySelector('[data-search]').innerText = searchdata.anchors.map(a => `${a.element}#${a.id}: ${a.location}`).join(', ');
             }
             """
         Then There should be no logs
-        Then The selector "[data-search-one]" should contain "h2#cats: 4, li#ali: 6, h2#pagefind: 9"
+        Then The selector "[data-search]" should contain "h2#cats: 4, ul#list: 5, li#ali: 6, h2#pagefind: 9"
+
+    Scenario: Pagefind returns page anchor content in the fragment
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/_pagefind/pagefind.js");
+
+                let search = await pagefind.search("pageone");
+                let searchdata = await search.results[0].data();
+                document.querySelector('[data-search]').innerText = searchdata.anchors.map(a => `#${a.id}: '${a.text}'`).join(', ');
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-search]" should contain "#cats: 'Cats', #list: '', #ali: 'Ali', #pagefind: 'Pagefind'"
+
+    Scenario: Pagefind extracts page anchor text where it makes sense
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/_pagefind/pagefind.js");
+
+                let search = await pagefind.search("pagetwo");
+                let searchdata = await search.results[0].data();
+                document.querySelector('[data-search]').innerHTML = `
+                    <ul>
+                        ${searchdata.anchors.map(a => `<li>#${a.id}: '${a.text}'</li>`)}
+                    </ul>
+                `;
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-search]>ul>li:nth-of-type(1)" should contain "#h1: 'PageTwo, from Pagefind'"
+        Then The selector "[data-search]>ul>li:nth-of-type(2)" should contain "#p_spans: 'Words in spans should be extracted'"
+        Then The selector "[data-search]>ul>li:nth-of-type(3)" should contain "#h2_hrefs: 'Links should be extracted'"
+        Then The selector "[data-search]>ul>li:nth-of-type(4)" should contain "#span_formatted: 'Text that is bold or italic should be extracted'"
+        Then The selector "[data-search]>ul>li:nth-of-type(5)" should contain "#p_nested_ids: 'Text containing nested IDs should extract both'"
+        Then The selector "[data-search]>ul>li:nth-of-type(6)" should contain "#span_nested: 'nested IDs'"
+        Then The selector "[data-search]>ul>li:nth-of-type(7)" should contain "#double_div: 'Divs containing divs should only take from the top level'"

--- a/pagefind/src/fossick/parser.rs
+++ b/pagefind/src/fossick/parser.rs
@@ -710,7 +710,7 @@ mod tests {
 
         assert_eq!(
             data.digest,
-            "Sentence one. ___PAGEFIND_ANCHOR___br:break ___PAGEFIND_ANCHOR___p:pid Sentence two."
+            "Sentence one. ___PAGEFIND_ANCHOR___br:0:break ___PAGEFIND_ANCHOR___p:1:pid Sentence two."
         )
     }
 

--- a/pagefind/src/fragments/mod.rs
+++ b/pagefind/src/fragments/mod.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 pub struct PageAnchorData {
     pub element: String,
     pub id: String,
-    pub text: Option<String>,
+    pub text: String,
     pub location: u32,
 }
 

--- a/pagefind/src/service/mod.rs
+++ b/pagefind/src/service/mod.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use base64::{engine::general_purpose, Engine as _};
+use hashbrown::HashMap;
 use rust_patch::Patch;
 use tokio::sync::mpsc;
 
@@ -190,6 +191,7 @@ pub async fn run_service() {
                         filters: filters.unwrap_or_default(),
                         sort: sort.unwrap_or_default(),
                         meta: meta.unwrap_or_default(),
+                        anchor_content: HashMap::new(),
                         has_custom_body: false,
                         force_inclusion: true,
                         has_html_element: true,


### PR DESCRIPTION
This PR fills out the next iteration of support for #215 — namely returning the `"text"` parameter for anchors when returning a result. This is the last step before having Pagefind calculate the correct heading for you, which will come in another PR.

The way this text is extracted could be up for debate, but the chosen method seems sane. For anchors, Pagefind will use all text that is either a direct descendant of the element, or is within strictly inline elements.

For example:
```
<h2 id="my_id">This title with a <span>span<span>!</h2>
```
will result in a `my_id` anchor with the text `This title with a span!`.

However,
```
<div id="my_id">This div with a <div>nested div<div>!</div>
```
will result in a `my_id` anchor with the text `This div with a!`.

This is to prevent having something `<body id="body">` result in an anchor containing the entire page again.