### PR TITLE
Implement smart indexing of compound words

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,6 +610,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cookie"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,7 +727,7 @@ version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1802,6 +1811,7 @@ dependencies = [
  "charabia",
  "clap 4.1.11",
  "console",
+ "convert_case 0.6.0",
  "flate2",
  "futures",
  "hashbrown 0.13.1",

--- a/pagefind/Cargo.toml
+++ b/pagefind/Cargo.toml
@@ -48,6 +48,7 @@ pagefind_stem = { version = "0.2.0", features = [
     "turkish",
     "yiddish",
 ] }
+convert_case = "0.6.0"
 charabia = { version = "0.7.0", optional = true }
 hashbrown = { version = "0.13.1", features = ["serde"] }
 regex = "1.1"

--- a/pagefind/src/fossick/splitting.rs
+++ b/pagefind/src/fossick/splitting.rs
@@ -1,0 +1,42 @@
+use convert_case::{Case, Casing};
+
+pub fn get_discrete_words<S: AsRef<str>>(s: S) -> String {
+    s.as_ref()
+        .replace(|c| c == '.' || c == ',' || c == '/' || c == ':', " ")
+        .to_case(Case::Lower)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hyphenated_words() {
+        let input = "these-words-are-hyphenated";
+        assert_eq!(get_discrete_words(input), "these words are hyphenated");
+    }
+
+    #[test]
+    fn underscored_words() {
+        let input = "__array_structures";
+        assert_eq!(get_discrete_words(input), "array structures");
+    }
+
+    #[test]
+    fn camel_words() {
+        let input = "WKWebVIEWComponent";
+        assert_eq!(get_discrete_words(input), "wk web view component");
+    }
+
+    #[test]
+    fn dotted_words() {
+        let input = "page.Find";
+        assert_eq!(get_discrete_words(input), "page find");
+    }
+
+    #[test]
+    fn misc_punctuation() {
+        let input = "cloud/cannon,page.find";
+        assert_eq!(get_discrete_words(input), "cloud cannon page find");
+    }
+}

--- a/pagefind/src/logging.rs
+++ b/pagefind/src/logging.rs
@@ -69,7 +69,7 @@ impl Logger {
 
         Self {
             log_level,
-            out: if (use_terminal) {
+            out: if use_terminal {
                 Some(Term::stdout())
             } else {
                 None


### PR DESCRIPTION
Indexes words like `cloud-cannon`, `CloudCannon` as `cloud` and `cannon` separately to make either word searchable. 