### PR TITLE
Rename CLI options and change default Pagefind URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,10 @@ public
 .hugo_build.lock
 _gen
 pagefind_ui/default/_dev_files/_pagefind/ui.*
+pagefind_ui/default/_dev_files/pagefind/ui.*
 pagefind_ui/default/css
 pagefind_ui/modular/_dev_files/_pagefind/modular.*
+pagefind_ui/modular/_dev_files/pagefind/modular.*
 
 npm_dist
 

--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -13,8 +13,8 @@ Since Pagefind indexes your site _after_ it builds, we'll do things slightly out
 Pagefind provides a prebuilt search UI out of the box. Add the following snippet to a page of your choice:
 
 ```html
-<link href="/_pagefind/pagefind-ui.css" rel="stylesheet">
-<script src="/_pagefind/pagefind-ui.js"></script>
+<link href="/pagefind/pagefind-ui.css" rel="stylesheet">
+<script src="/pagefind/pagefind-ui.js"></script>
 <div id="search"></div>
 <script>
     window.addEventListener('DOMContentLoaded', (event) => {
@@ -23,7 +23,7 @@ Pagefind provides a prebuilt search UI out of the box. Add the following snippet
 </script>
 ```
 
-> The `/_pagefind/pagefind-ui.css` and `/_pagefind/pagefind-ui.js` assets will be created by Pagefind when we index the site.
+> The `/pagefind/pagefind-ui.css` and `/pagefind/pagefind-ui.js` assets will be created by Pagefind when we index the site.
 
 Now build your site to an output directory — this guide assumes that you're running `hugo` and that your site is output to the `public/` directory. Pagefind works with any set of static HTML files, so adjust these configurations as needed.
 
@@ -31,12 +31,12 @@ Now build your site to an output directory — this guide assumes that you're ru
 
 ## Indexing your site
 
-The easiest way to run pagefind is through npx, where `--source` points to the output directory of your static site generator. We'll also add `--serve` so that we can view our final site right away.
+The easiest way to run pagefind is through npx, where `--site` points to the output directory of your static site generator. We'll also add `--serve` so that we can view our final site right away.
 
 > Note that Pagefind itself does not have any server component — the search integration is fully baked into your static site. The `--serve` flag here is a shortcut for running Pagefind, followed by serving your output site through any static web server.
 
 ```bash
-npx -y pagefind --source public --serve
+npx -y pagefind --site public --serve
 ```
 
 You should see some output along the lines of:

--- a/docs/content/docs/api.md
+++ b/docs/content/docs/api.md
@@ -13,10 +13,10 @@ Pagefind can be accessed as an API directly from JavaScript, for you to build cu
 Anywhere on your site, you can initialize Pagefind with:
 
 ```js
-const pagefind = await import("/_pagefind/pagefind.js");
+const pagefind = await import("/pagefind/pagefind.js");
 ```
 
-This will load the Pagefind library and the metadata about the site. If your site is on a subpath, this should be included — e.g. in the CloudCannon documentation, we load `/documentation/_pagefind/pagefind.js`.
+This will load the Pagefind library and the metadata about the site. If your site is on a subpath, this should be included — e.g. in the CloudCannon documentation, we load `/documentation/pagefind/pagefind.js`.
 
 > If building your own search UI, it is a good idea to only run this import once your search component has received interaction. This saves the user from loading the Pagefind library on every page request.
 
@@ -25,7 +25,7 @@ This will load the Pagefind library and the metadata about the site. If your sit
 To perform a search, await `pagefind.search`:
 {{< diffcode >}}
 ```js
-const pagefind = await import("/_pagefind/pagefind.js");
+const pagefind = await import("/pagefind/pagefind.js");
 +const search = await pagefind.search("static");
 ```
 {{< /diffcode >}}
@@ -50,7 +50,7 @@ To load the data for a result, await the data function:
 
 {{< diffcode >}}
 ```js
-const pagefind = await import("/_pagefind/pagefind.js");
+const pagefind = await import("/pagefind/pagefind.js");
 const search = await pagefind.search("static");
 +const oneResult = await search.results[0].data();
 ```
@@ -80,7 +80,7 @@ To load a "page" of results, you can run something like the following:
 
 {{< diffcode >}}
 ```js
-const pagefind = await import("/_pagefind/pagefind.js");
+const pagefind = await import("/pagefind/pagefind.js");
 const search = await pagefind.search("static");
 +const fiveResults = await Promise.all(search.results.slice(0, 5).map(r => r.data()));
 ```
@@ -215,7 +215,7 @@ const search = await pagefind.search(null, {
 The helper function `pagefind.debouncedSearch` is available and can be used in place of `pagefind.search`:
 {{< diffcode >}}
 ```js
-const pagefind = await import("/_pagefind/pagefind.js");
+const pagefind = await import("/pagefind/pagefind.js");
 +const search = await pagefind.debouncedSearch("static");
 ```
 {{< /diffcode >}}
@@ -223,7 +223,7 @@ const pagefind = await import("/_pagefind/pagefind.js");
 A custom debounce timeout (default: `300`) can optionally be specified as the third argument:
 {{< diffcode >}}
 ```js
-const pagefind = await import("/_pagefind/pagefind.js");
+const pagefind = await import("/pagefind/pagefind.js");
 +const search = await pagefind.debouncedSearch("static", {/* options */}, 300);
 ```
 {{< /diffcode >}}
@@ -247,7 +247,7 @@ If you have a debounced search input, Pagefind won't start loading indexes until
 
 {{< diffcode >}}
 ```js
-const pagefind = await import("/_pagefind/pagefind.js");
+const pagefind = await import("/pagefind/pagefind.js");
 +pagefind.preload("s");
 
 // later...

--- a/docs/content/docs/config-options.md
+++ b/docs/content/docs/config-options.md
@@ -12,28 +12,35 @@ The Pagefind CLI has the following options:
 
 ## Required arguments
 
-### Source
+### Site
 The location of your built static site.
 
-| CLI Flag            | ENV Variable      | Config Key |
-|---------------------|-------------------|------------|
-| `--source <SOURCE>` | `PAGEFIND_SOURCE` | `source`   |
+| CLI Flag        | ENV Variable    | Config Key |
+|-----------------|-----------------|------------|
+| `--site <PATH>` | `PAGEFIND_SITE` | `site`     |
 
 ## Optional arguments
 
 ### Serve
-Serve the source directory after creating the search index. Useful for testing search on a local build of your site without having to serve the source directory manually.
+Serve the site directory after creating the search index. Useful for testing search on a local build of your site without having to serve the site directory manually.
 
 | CLI Flag  | ENV Variable     | Config Key |
 |-----------|------------------|------------|
 | `--serve` | `PAGEFIND_SERVE` | `serve`    |
 
-### Bundle directory
-The folder to output search files into, relative to source. Defaults to `_pagefind`.
+### Output subdirectory
+The folder to output the search bundle into, relative to the processed site. Defaults to `pagefind`.
 
-| CLI Flag             | ENV Variable          | Config Key   |
-|----------------------|-----------------------|--------------|
-| `--bundle-dir <DIR>` | `PAGEFIND_BUNDLE_DIR` | `bundle_dir` |
+| CLI Flag                | ENV Variable             | Config Key      |
+|-------------------------|--------------------------|-----------------|
+| `--output-subdir <DIR>` | `PAGEFIND_OUTPUT_SUBDIR` | `output_subdir` |
+
+### Output path
+The folder to output the search bundle into, relative to the working directory. Overrides `output-subdir` if supplied.
+
+| CLI Flag               | ENV Variable           | Config Key    |
+|------------------------|------------------------|---------------|
+| `--output-path <PATH>` | `PAGEFIND_OUTPUT_PATH` | `output_path` |
 
 ### Root selector
 The element that Pagefind should treat as the root of the document. Defaults to `html`.

--- a/docs/content/docs/config-sources.md
+++ b/docs/content/docs/config-sources.md
@@ -14,8 +14,8 @@ Pagefind will look for a `pagefind.toml`, `pagefind.yml`, `pagefind.yaml`, or `p
 
 ```yaml
 # pagefind.yml
-source: public
-bundle_dir: _pagefind
+site: public
+output_subdir: pagefind
 ```
 ```bash
 npx pagefind
@@ -26,8 +26,8 @@ npx pagefind
 Pagefind will load any values via a `PAGEFIND_*` environment variable.
 
 ```bash
-export PAGEFIND_BUNDLE_DIR="_pagefind"
-PAGEFIND_SOURCE="public" npx pagefind
+export PAGEFIND_OUTPUT_SUBDIR="pagefind"
+PAGEFIND_SITE="public" npx pagefind
 ```
 
 ## CLI flags
@@ -35,5 +35,5 @@ PAGEFIND_SOURCE="public" npx pagefind
 Pagefind can be passed CLI flags directly.
 
 ```bash
-npx pagefind --source public --bundle-dir _pagefind
+npx pagefind --site public --output-subdir pagefind
 ```

--- a/docs/content/docs/hosting.md
+++ b/docs/content/docs/hosting.md
@@ -12,10 +12,6 @@ Pagefind outputs a static bundle directory to your built site, and no hosting co
 
 Pagefind handles compression of the files in the bundle directly, so no server gzip support is required.
 
-## Hosting on GitHub Pages
-
-GitHub Pages won't serve URLs that start with a leading underscore, so the default path of `_pagefind` will 404. To fix this, set a custom [bundle directory](https://pagefind.app/docs/config-options/#bundle-directory) (_e.g. `--bundle-dir mysearch`_), and update your JS and CSS references to match (_e.g. `<script src="/mysearch/pagefind-ui.js" ...`_).
-
 ## Content Security Policy (CSP)
 
 If you have a strict content security policy enabled on your site, you may encounter issues with the Pagefind WebAssembly — this isn't specific to Pagefind but is an issue with CSP and WebAssembly.

--- a/docs/content/docs/installation.md
+++ b/docs/content/docs/installation.md
@@ -11,7 +11,7 @@ Pagefind is a static binary with no dynamic dependencies, so in most cases will 
 ## Running via npx
 
 ```bash
-npx pagefind --source "public"
+npx pagefind --site "public"
 ```
 
 Pagefind publishes a [wrapper package through npm](https://www.npmjs.com/package/pagefind), which is the easiest way to get started. This package will download the correct [binary of the latest release](https://github.com/CloudCannon/pagefind/releases) from GitHub for your platform and run it.
@@ -19,9 +19,9 @@ Pagefind publishes a [wrapper package through npm](https://www.npmjs.com/package
 Specific versions can be run by passing a version tag:
 
 ```bash
-npx pagefind@latest --source "public"
+npx pagefind@latest --site "public"
 
-npx pagefind@v0.2.0 --source "public"
+npx pagefind@v0.2.0 --site "public"
 ```
 
 > Running Pagefind via npx will download the `pagefind_extended` release, which includes specialized support for indexing Chinese and Japanese pages.
@@ -31,9 +31,9 @@ npx pagefind@v0.2.0 --source "public"
 If you prefer to install Pagefind yourself, you can download a [precompiled release from GitHub](https://github.com/CloudCannon/pagefind/releases) and run the binary directly:
 
 ```bash
-./pagefind --source "public"
+./pagefind --site "public"
 # or
-./pagefind_extended --source "public"
+./pagefind_extended --site "public"
 ```
 
 Pagefind publishes two releases, `pagefind` and `pagefind_extended`. The extended release is a larger binary, but includes specialized support for indexing Chinese and Japanese pages.
@@ -44,12 +44,12 @@ If you have [Rust and Cargo](https://doc.rust-lang.org/cargo/getting-started/ins
 
 ```bash
 cargo install pagefind
-pagefind --source "public"
+pagefind --site "public"
 ```
 
 To build and install the extended version of Pagefind:
 
 ```bash
 cargo install pagefind --features extended
-pagefind --source "public"
+pagefind --site "public"
 ```

--- a/docs/content/docs/multisite.md
+++ b/docs/content/docs/multisite.md
@@ -21,7 +21,7 @@ When initializing the Pagefind UI, include a `mergeIndex` option with an array o
 new PagefindUI({
     element: "#search",
 +    mergeIndex: [{
-+        bundlePath: "https://docs.example.com/_pagefind"
++        bundlePath: "https://docs.example.com/pagefind"
 +    }]
 })
 ```
@@ -37,7 +37,7 @@ new PagefindUI({
     element: "#search",
 +    // ... options for the blog.example.com index
     mergeIndex: [{
-        bundlePath: "https://docs.example.com/_pagefind",
+        bundlePath: "https://docs.example.com/pagefind",
 +        // ... options for the docs.example.com index
     }]
 })
@@ -52,8 +52,8 @@ Using an initialized instance of Pagefind, await the `mergeIndex` function to ad
 ```js
 // Running on blog.example.com
 
-const pagefind = await import("/_pagefind/pagefind.js");
-+await pagefind.mergeIndex("https://docs.example.com/_pagefind");
+const pagefind = await import("/pagefind/pagefind.js");
++await pagefind.mergeIndex("https://docs.example.com/pagefind");
 ```
 {{< /diffcode >}}
 
@@ -63,10 +63,10 @@ Pagefind options can be passed to the additional index as a second argument:
 ```js
 // Running on blog.example.com
 
-const pagefind = await import("/_pagefind/pagefind.js");
+const pagefind = await import("/pagefind/pagefind.js");
 +await pagefind.options({/* ... options for the blog.example.com index */});
 await pagefind.mergeIndex(
-  "https://docs.example.com/_pagefind",
+  "https://docs.example.com/pagefind",
 +  {/* ... options for the docs.example.com index */}
 );
 ```
@@ -83,15 +83,15 @@ new PagefindUI({
     element: "#search",
 +   indexWeight: 2,
     mergeIndex: [{
-        bundlePath: "https://docs.example.com/_pagefind",
+        bundlePath: "https://docs.example.com/pagefind",
 +        indexWeight: 0.5
     }]
 })
 
 // JS API:
-const pagefind = await import("/_pagefind/pagefind.js");
+const pagefind = await import("/pagefind/pagefind.js");
 +await pagefind.options({ indexWeight: 2 });
-await pagefind.mergeIndex("https://docs.example.com/_pagefind", {
+await pagefind.mergeIndex("https://docs.example.com/pagefind", {
 +    indexWeight: 0.5
 });
 ```
@@ -110,7 +110,7 @@ new PagefindUI({
 +        resource: "Blog"
 +    },
     mergeIndex: [{
-        bundlePath: "https://docs.example.com/_pagefind",
+        bundlePath: "https://docs.example.com/pagefind",
 +        mergeFilter: {
 +            resource: "Documentation"
 +        }
@@ -118,9 +118,9 @@ new PagefindUI({
 })
 
 // JS API:
-const pagefind = await import("/_pagefind/pagefind.js");
+const pagefind = await import("/pagefind/pagefind.js");
 +await pagefind.options({ mergeFilter: { resource: "Blog" } });
-await pagefind.mergeIndex("https://docs.example.com/_pagefind", {
+await pagefind.mergeIndex("https://docs.example.com/pagefind", {
 +    mergeFilter: {
 +        resource: "Documentation"
 +    }
@@ -138,14 +138,14 @@ Pagefind will attempt to grab a matching language when merging an index, falling
 new PagefindUI({
     element: "#search",
     mergeIndex: [{
-        bundlePath: "https://docs.example.com/_pagefind",
+        bundlePath: "https://docs.example.com/pagefind",
 +        language: "pt-br"
     }]
 })
 
 // JS API:
-const pagefind = await import("/_pagefind/pagefind.js");
-await pagefind.mergeIndex("https://docs.example.com/_pagefind", {
+const pagefind = await import("/pagefind/pagefind.js");
+await pagefind.mergeIndex("https://docs.example.com/pagefind", {
 +    language: "pt-br"
 });
 ```
@@ -161,7 +161,7 @@ Due to index merging happening in the browser, your additional search indexes mu
 {
   "headers": [
     {
-      "match": "/_pagefind/.*",
+      "match": "/pagefind/.*",
       "headers": [
         {
           "name": "Access-Control-Allow-Origin",

--- a/docs/content/docs/search-config.md
+++ b/docs/content/docs/search-config.md
@@ -28,7 +28,7 @@ If interfacing with Pagefind directly, options can be passed via awaiting `pagef
 
 {{< diffcode >}}
 ```js
-const pagefind = await import("/_pagefind/pagefind.js");
+const pagefind = await import("/pagefind/pagefind.js");
 +await pagefind.options({
 +    baseUrl: "/",
 +    // ... more search options
@@ -53,7 +53,7 @@ Defaults to "/". If hosting a site on a subpath, `baseUrl` can be provided, and 
 
 ```json
 {
-    "bundlePath": "/subpath/_pagefind/"
+    "bundlePath": "/subpath/pagefind/"
 }
 ```
 

--- a/docs/content/docs/ui.md
+++ b/docs/content/docs/ui.md
@@ -10,11 +10,11 @@ Pagefind provides a UI component that supports searching, filtering, and metadat
 
 ## Adding the Pagefind UI to a page
 
-Pagefind UI can be added to any page with the following snippet. The `/_pagefind/` directory and containing files will be created for you when running the Pagefind CLI.
+Pagefind UI can be added to any page with the following snippet. The `/pagefind/` directory and containing files will be created for you when running the Pagefind CLI.
 
 ```html
-<link href="/_pagefind/pagefind-ui.css" rel="stylesheet">
-<script src="/_pagefind/pagefind-ui.js"></script>
+<link href="/pagefind/pagefind-ui.css" rel="stylesheet">
+<script src="/pagefind/pagefind-ui.js"></script>
 
 <div id="search"></div>
 <script>
@@ -56,7 +56,7 @@ body.dark {
 
 ## Styling Pagefind UI yourself
 
-Pagefind UI can be styled manually by omitting the `/_pagefind/pagefind-ui.css` stylesheet. In this case it will function as a pure HTML component.
+Pagefind UI can be styled manually by omitting the `/pagefind/pagefind-ui.css` stylesheet. In this case it will function as a pure HTML component.
 
 The classnames within Pagefind UI that begin with `pagefind-ui` should be targeted. These may change, so if you are styling them yourself make sure to test new releases of Pagefind with your stylesheet. Changes to classnames will be highlighted in the release notes, but will not be signalled by a major release.
 
@@ -184,7 +184,7 @@ By default, Pagefind UI applies a CSS reset to itself. Pass `false` to omit this
 ```javascript
 new PagefindUI({
     element: "#search",
-+    bundlePath: "/subpath/_pagefind/"
++    bundlePath: "/subpath/pagefind/"
 });
 ```
 {{< /diffcode >}}

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -29,7 +29,7 @@
     <meta content="summary_large_image" name="twitter:card">
     <meta content="{{"/og.png" | absURL}}" property="twitter:image">
 
-    <link href="/_pagefind/pagefind-ui.css" rel="stylesheet">
+    <link href="/pagefind/pagefind-ui.css" rel="stylesheet">
     {{ $style := resources.Get "css/site.scss" | toCSS | minify | fingerprint }}
     <link rel="stylesheet" href="{{ $style.Permalink }}">
 
@@ -41,7 +41,7 @@
     {{ partial "banner.html" }}
     {{ partial "nav.html" }}
     <div class="search">
-        <script src="/_pagefind/pagefind-ui.js"></script>
+        <script src="/pagefind/pagefind-ui.js"></script>
         <div id="search"></div>
     </div>
     <div class="column">

--- a/pagefind/features/anchors.feature
+++ b/pagefind/features/anchors.feature
@@ -2,7 +2,7 @@ Feature: Anchors
 
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
         Given I have a "public/index.html" file with the body:
             """
             <p data-search>Nothing</p>
@@ -55,7 +55,7 @@ Feature: Anchors
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("pageone");
                 let searchdata = await search.results[0].data();
@@ -69,7 +69,7 @@ Feature: Anchors
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("pageone");
                 let searchdata = await search.results[0].data();
@@ -83,7 +83,7 @@ Feature: Anchors
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("pageone");
                 let searchdata = await search.results[0].data();
@@ -97,7 +97,7 @@ Feature: Anchors
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("pageone");
                 let searchdata = await search.results[0].data();
@@ -111,7 +111,7 @@ Feature: Anchors
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("pagetwo");
                 let searchdata = await search.results[0].data();
@@ -135,7 +135,7 @@ Feature: Anchors
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("extracted");
                 let searchdata = await search.results[0].data();

--- a/pagefind/features/anchors_example.feature
+++ b/pagefind/features/anchors_example.feature
@@ -2,7 +2,7 @@ Feature: Anchors Example
 
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
         Given I have a "public/index.html" file with the body:
             """
             <p data-search>Nothing</p>
@@ -36,7 +36,7 @@ Feature: Anchors Example
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("pagefind");
                 let searchdata = await search.results[0].data();

--- a/pagefind/features/base.feature
+++ b/pagefind/features/base.feature
@@ -1,7 +1,7 @@
 Feature: Base Tests
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
         Given I have a "public/index.html" file with the body:
             """
             <p data-url>Nothing</p>
@@ -14,13 +14,13 @@ Feature: Base Tests
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("world");
 
@@ -38,13 +38,13 @@ Feature: Base Tests
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 await pagefind.preload("wo");
                 let search = await pagefind.search("world");
@@ -63,13 +63,13 @@ Feature: Base Tests
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search(null);
 

--- a/pagefind/features/build_options.feature
+++ b/pagefind/features/build_options.feature
@@ -1,7 +1,7 @@
 Feature: Build Options
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
 
     Scenario: Source folder can be configured
         Given I have a "my_website/index.html" file with the body:
@@ -13,15 +13,15 @@ Feature: Build Options
             <h1>world</h1>
             """
         When I run my program with the flags:
-            | --source my_website |
+            | --site my_website |
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "my_website/_pagefind/pagefind.js"
+        Then I should see the file "my_website/pagefind/pagefind.js"
         When I serve the "my_website" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("world");
 
@@ -42,7 +42,7 @@ Feature: Build Options
             <h1>world</h1>
             """
         When I run my program with the flags:
-            | --bundle-dir _search |
+            | --output-subdir _search |
         Then I should see "Running Pagefind" in stdout
         Then I should see the file "public/_search/pagefind.js"
         When I serve the "public" directory
@@ -71,9 +71,9 @@ Feature: Build Options
             <h1>world</h1>
             """
         # {{humane_temp_dir}} will be replaced with an absolute path here,
-        # making the bundle-dir value absolute
+        # making the output-subdir value absolute
         When I run my program with the flags:
-            | --bundle-dir {{humane_temp_dir}}/other/_search |
+            | --output-subdir {{humane_temp_dir}}/other/_search |
         Then I should see "Running Pagefind" in stdout
         Then I should see the file "other/_search/pagefind.js"
         When I serve the "." directory
@@ -82,6 +82,35 @@ Feature: Build Options
             """
             async function() {
                 let pagefind = await import("/other/_search/pagefind.js");
+
+                let search = await pagefind.search("world");
+
+                let data = await search.results[0].data();
+                document.querySelector('[data-url]').innerText = data.url;
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-url]" should contain "/cat/"
+
+    Scenario: Output path can be configured relative to cwd
+        Given I have a "public/index.html" file with the body:
+            """
+            <p data-url>Nothing</p>
+            """
+        Given I have a "public/cat/index.html" file with the body:
+            """
+            <h1>world</h1>
+            """
+        When I run my program with the flags:
+            | --output-path misc/_search |
+        Then I should see "Running Pagefind" in stdout
+        Then I should see the file "misc/_search/pagefind.js"
+        When I serve the "." directory
+        When I load "/public/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/misc/_search/pagefind.js");
 
                 let search = await pagefind.search("world");
 
@@ -108,13 +137,13 @@ Feature: Build Options
         When I run my program with the flags:
             | --root-selector "body > .content" |
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("hello");
 
@@ -140,13 +169,13 @@ Feature: Build Options
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("world");
 
@@ -184,13 +213,13 @@ Feature: Build Options
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("cat");
 

--- a/pagefind/features/characters.feature
+++ b/pagefind/features/characters.feature
@@ -1,7 +1,7 @@
 Feature: Character Tests
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
         Given I have a "public/index.html" file with the body:
             """
             <p data-result>Nothing</p>
@@ -14,13 +14,13 @@ Feature: Character Tests
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("Béës");
 
@@ -38,13 +38,13 @@ Feature: Character Tests
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("bees");
 
@@ -62,13 +62,13 @@ Feature: Character Tests
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("beet-root");
 
@@ -86,13 +86,13 @@ Feature: Character Tests
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 // Preload some pages that Pagefind might then return as "all pages"
                 await pagefind.preload("can");
@@ -132,13 +132,13 @@ Feature: Character Tests
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let pages = [
                     ...(await Promise.all((await pagefind.search("beet")).results.map(r => r.data()))),
@@ -153,7 +153,7 @@ Feature: Character Tests
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let pages = [
                     ...(await Promise.all((await pagefind.search("image")).results.map(r => r.data()))),
@@ -168,7 +168,7 @@ Feature: Character Tests
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let pages = [
                     ...(await Promise.all((await pagefind.search("WkWebVIEWComponent")).results.map(r => r.data()))),
@@ -184,7 +184,7 @@ Feature: Character Tests
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let pages = [
                     ...(await Promise.all((await pagefind.search("word")).results.map(r => r.data()))),
@@ -199,7 +199,7 @@ Feature: Character Tests
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let pages = [
                     ...(await Promise.all((await pagefind.search("sandwich")).results.map(r => r.data()))),
@@ -214,7 +214,7 @@ Feature: Character Tests
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let pages = [
                     ...(await Promise.all((await pagefind.search("CloudCannon")).results.map(r => r.data()))),
@@ -241,13 +241,13 @@ Feature: Character Tests
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("anotherword");
 

--- a/pagefind/features/compound_filtering.feature
+++ b/pagefind/features/compound_filtering.feature
@@ -1,7 +1,7 @@
 Feature: Filtering
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
         Given I have a "public/index.html" file with the body:
             """
             <p data-results>Nothing</p>
@@ -53,7 +53,7 @@ Feature: Filtering
         When I evaluate:
             """
             async function() {
-                window.pagefind = await import("/_pagefind/pagefind.js");
+                window.pagefind = await import("/pagefind/pagefind.js");
 
                 window.test = async function(pagefind_incantation) {
                     let search = await pagefind_incantation;

--- a/pagefind/features/config_sources.feature
+++ b/pagefind/features/config_sources.feature
@@ -7,11 +7,11 @@ Feature: Config Sources
             """
         Given I have a "pagefind.toml" file with the content:
             """
-            source = "public"
+            site = "public"
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
 
     Scenario: Settings can be pulled from YAML configuration files
         Given I have a "public/index.html" file with the body:
@@ -20,11 +20,11 @@ Feature: Config Sources
             """
         Given I have a "pagefind.yml" file with the content:
             """
-            source: public
+            site: public
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
 
     Scenario: Settings can be pulled from JSON configuration files
         Given I have a "public/index.html" file with the body:
@@ -34,12 +34,12 @@ Feature: Config Sources
         Given I have a "pagefind.json" file with the content:
             """
             {
-                "source": "public"
+                "site": "public"
             }
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
 
     Scenario: Settings can be pulled from command-line flags
         Given I have a "public/index.html" file with the body:
@@ -47,9 +47,9 @@ Feature: Config Sources
             <h1>Hello.</h1>
             """
         When I run my program with the flags:
-            | --source public |
+            | --site public |
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
 
     Scenario: Settings can be pulled from environment variables
         Given I have a "public/index.html" file with the body:
@@ -57,10 +57,10 @@ Feature: Config Sources
             <h1>Hello.</h1>
             """
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
 
     Scenario: Settings can be pulled from multiple sources
         Given I have a "public/index.html" file with the body:
@@ -70,10 +70,10 @@ Feature: Config Sources
         Given I have a "pagefind.json" file with the content:
             """
             {
-                "source": "public"
+                "site": "public"
             }
             """
         When I run my program with the flags:
-            | --bundle-dir _out |
+            | --output-subdir _out |
         Then I should see "Running Pagefind" in stdout
         Then I should see the file "public/_out/pagefind.js"

--- a/pagefind/features/debounce.feature
+++ b/pagefind/features/debounce.feature
@@ -1,7 +1,7 @@
 Feature: Debounced Searches
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
         Given I have a "public/index.html" file with the body:
             """
             <p data-types>Nothing</p>
@@ -15,13 +15,13 @@ Feature: Debounced Searches
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let results = await Promise.all([
                     pagefind.debouncedSearch("a"),

--- a/pagefind/features/edge_cases.feature
+++ b/pagefind/features/edge_cases.feature
@@ -1,7 +1,7 @@
 Feature: Graceful Pagefind Errors
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
         Given I have a "public/index.html" file with the body:
             """
             <p data-url>Nothing</p>
@@ -19,13 +19,13 @@ Feature: Graceful Pagefind Errors
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("world");
                 let results = await Promise.all(search.results.map(r => r.data()));
@@ -59,13 +59,13 @@ Feature: Graceful Pagefind Errors
         When I run my program
         Then I should see "Running Pagefind" in stdout
         Then I should see "Found a data-pagefind-body element on the site" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("world");
                 let results = await Promise.all(search.results.map(r => r.data()));

--- a/pagefind/features/exact_phrase.feature
+++ b/pagefind/features/exact_phrase.feature
@@ -1,7 +1,7 @@
 Feature: Exact Phrase Matching
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
         Given I have a "public/index.html" file with the body:
             """
             <p data-count>Nothing</p>
@@ -19,13 +19,13 @@ Feature: Exact Phrase Matching
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search(`"about cats"`);
 
@@ -56,7 +56,7 @@ Feature: Exact Phrase Matching
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search(`"post about"`);
 

--- a/pagefind/features/exclusions.feature
+++ b/pagefind/features/exclusions.feature
@@ -2,7 +2,7 @@ Feature: Exclusions
 
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
 
     Scenario: Elements within search regions can be excluded from indexing and excerpts
         Given I have a "public/index.html" file with the body:
@@ -26,7 +26,7 @@ Feature: Exclusions
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let searchone = await pagefind.search("hello");
                 let searchonedata = await searchone.results[0].data();
@@ -67,7 +67,7 @@ Feature: Exclusions
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let searchone = await pagefind.search("hello");
                 let searchonedata = await searchone.results[0].data();
@@ -106,7 +106,7 @@ Feature: Exclusions
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("hello");
                 let searchdata = await search.results[0].data();
@@ -150,7 +150,7 @@ Feature: Exclusions
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let searchone = await pagefind.search("hello");
                 let searchonedata = await searchone.results[0].data();

--- a/pagefind/features/filtering.feature
+++ b/pagefind/features/filtering.feature
@@ -1,7 +1,7 @@
 Feature: Filtering
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
         Given I have a "public/index.html" file with the body:
             """
             <p data-results>Nothing</p>
@@ -31,7 +31,7 @@ Feature: Filtering
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let filters = await pagefind.filters();
                 let strings = Object.entries(filters).map(([filter, values]) => {
@@ -51,7 +51,7 @@ Feature: Filtering
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("Cat");
                 let data = await Promise.all(search.results.map(result => result.data()));
@@ -66,7 +66,7 @@ Feature: Filtering
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("Cat", {
                     filters: {
@@ -85,7 +85,7 @@ Feature: Filtering
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("Cat", {
                     filters: {
@@ -104,7 +104,7 @@ Feature: Filtering
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("Cat", {
                     filters: {
@@ -123,7 +123,7 @@ Feature: Filtering
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search(null, {
                     filters: {
@@ -142,7 +142,7 @@ Feature: Filtering
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 // Run a search so that some index words are loaded
                 let unused = await pagefind.search("cat");
@@ -164,7 +164,7 @@ Feature: Filtering
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("Cat", {
                     filters: {
@@ -182,7 +182,7 @@ Feature: Filtering
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("Cat", {
                     filters: {
@@ -200,7 +200,7 @@ Feature: Filtering
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("Pontification", {
                     filters: {
@@ -218,7 +218,7 @@ Feature: Filtering
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 await pagefind.filters(); // Load filters
                 let search = await pagefind.search("Ali");
@@ -239,7 +239,7 @@ Feature: Filtering
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 await pagefind.filters(); // Load filters
                 let search = await pagefind.search("Cat", {
@@ -264,7 +264,7 @@ Feature: Filtering
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 await pagefind.filters(); // Load filters
                 let search = await pagefind.search("Ali", {
@@ -282,7 +282,7 @@ Feature: Filtering
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("Cat", {
                     filters: {
@@ -301,7 +301,7 @@ Feature: Filtering
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("Cat", {
                     filters: {

--- a/pagefind/features/frozen-pre-1.0/base.feature
+++ b/pagefind/features/frozen-pre-1.0/base.feature
@@ -1,0 +1,67 @@
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# This file represents a backwards-compatible setup as it existed before 1.0  #
+# These tests should remain as a permanent regresison check for older sites   #
+# It is very unlikely that the tests in this file should be touched           #
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+Feature: Base Tests
+    Background:
+        Given I have the environment variables:
+            | PAGEFIND_SOURCE | public |
+        Given I have a "public/index.html" file with the body:
+            """
+            <p data-url>Nothing</p>
+            """
+
+    Scenario: Search for a word
+        Given I have a "public/cat/index.html" file with the body:
+            """
+            <link rel="pre-1.0-signal" href="_pagefind" >
+            <h1>world</h1>
+            """
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "public/_pagefind/pagefind.js"
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/_pagefind/pagefind.js");
+
+                let search = await pagefind.search("world");
+
+                let data = await search.results[0].data();
+                document.querySelector('[data-url]').innerText = data.url;
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-url]" should contain "/cat/"
+
+    Scenario: Preload indexes then search for a word
+        Given I have a "public/cat/index.html" file with the body:
+            """
+            <link rel="pre-1.0-signal" href="_pagefind" >
+            <h1>world</h1>
+            """
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "public/_pagefind/pagefind.js"
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/_pagefind/pagefind.js");
+
+                await pagefind.preload("wo");
+                let search = await pagefind.search("world");
+
+                let data = await search.results[0].data();
+                document.querySelector('[data-url]').innerText = data.url;
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-url]" should contain "/cat/"

--- a/pagefind/features/frozen-pre-1.0/build_options.feature
+++ b/pagefind/features/frozen-pre-1.0/build_options.feature
@@ -1,0 +1,218 @@
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# This file represents a backwards-compatible setup as it existed before 1.0  #
+# These tests should remain as a permanent regresison check for older sites   #
+# It is very unlikely that the tests in this file should be touched           #
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+Feature: Build Options
+    Background:
+        Given I have the environment variables:
+            | PAGEFIND_SOURCE | public |
+
+    Scenario: Source folder can be configured
+        Given I have a "my_website/index.html" file with the body:
+            """
+            <link rel="pre-1.0-signal" href="_pagefind" >
+            <p data-url>Nothing</p>
+            """
+        Given I have a "my_website/cat/index.html" file with the body:
+            """
+            <h1>world</h1>
+            """
+        When I run my program with the flags:
+            | --source my_website |
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "my_website/_pagefind/pagefind.js"
+        When I serve the "my_website" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/_pagefind/pagefind.js");
+
+                let search = await pagefind.search("world");
+
+                let data = await search.results[0].data();
+                document.querySelector('[data-url]').innerText = data.url;
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-url]" should contain "/cat/"
+
+    Scenario: Output path can be configured
+        Given I have a "public/index.html" file with the body:
+            """
+            <link rel="pre-1.0-signal" href="_pagefind" >
+            <p data-url>Nothing</p>
+            """
+        Given I have a "public/cat/index.html" file with the body:
+            """
+            <h1>world</h1>
+            """
+        When I run my program with the flags:
+            | --bundle-dir _search |
+        Then I should see "Running Pagefind" in stdout
+        Then I should see the file "public/_search/pagefind.js"
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/_search/pagefind.js");
+
+                let search = await pagefind.search("world");
+
+                let data = await search.results[0].data();
+                document.querySelector('[data-url]').innerText = data.url;
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-url]" should contain "/cat/"
+
+    Scenario: Output path can be configured with an absolute path
+        Given I have a "public/index.html" file with the body:
+            """
+            <link rel="pre-1.0-signal" href="_pagefind" >
+            <p data-url>Nothing</p>
+            """
+        Given I have a "public/cat/index.html" file with the body:
+            """
+            <h1>world</h1>
+            """
+        # {{humane_temp_dir}} will be replaced with an absolute path here,
+        # making the bundle-dir value absolute
+        When I run my program with the flags:
+            | --bundle-dir {{humane_temp_dir}}/other/_search |
+        Then I should see "Running Pagefind" in stdout
+        Then I should see the file "other/_search/pagefind.js"
+        When I serve the "." directory
+        When I load "/public/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/other/_search/pagefind.js");
+
+                let search = await pagefind.search("world");
+
+                let data = await search.results[0].data();
+                document.querySelector('[data-url]').innerText = data.url;
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-url]" should contain "/cat/"
+
+    Scenario: Root selector can be configured
+        Given I have a "public/index.html" file with the body:
+            """
+            <link rel="pre-1.0-signal" href="_pagefind" >
+            <p data-url>Nothing</p>
+            """
+        Given I have a "public/cat/index.html" file with the body:
+            """
+            <h1>Ignored</h1>
+            <div class="content">
+                <h1>Hello</h1>
+            </div>
+            <p data-pagefind-meta="ignored">Also ignored</p>
+            """
+        When I run my program with the flags:
+            | --root-selector "body > .content" |
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "public/_pagefind/pagefind.js"
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/_pagefind/pagefind.js");
+
+                let search = await pagefind.search("hello");
+
+                let data = await search.results[0].data();
+                document.querySelector('[data-url]').innerText = `${data.meta.title}, ${data.content} Ignored is ${data.meta.ignored}.`;
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-url]" should contain "Hello, Hello. Ignored is undefined."
+
+    Scenario: File glob can be configured
+        Given I have a "public/index.html" file with the body:
+            """
+            <link rel="pre-1.0-signal" href="_pagefind" >
+            <p data-url>Nothing</p>
+            """
+        Given I have a "public/cat/index.htm" file with the body:
+            """
+            <h1>world</h1>
+            """
+        Given I have a "pagefind.yml" file with the content:
+            """
+            glob: "**/*.{htm,html}"
+            """
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "public/_pagefind/pagefind.js"
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/_pagefind/pagefind.js");
+
+                let search = await pagefind.search("world");
+
+                let data = await search.results[0].data();
+                document.querySelector('[data-url]').innerText = data.url;
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-url]" should contain "/cat/index.htm"
+
+    Scenario: Complex exclusionary file glob can be configured
+        Given I have a "public/index.html" file with the body:
+            """
+            <p data-result>Nothing</p>
+            """
+        Given I have a "public/cat/index.htm" file with the body:
+            """
+            <link rel="pre-1.0-signal" href="_pagefind" >
+            <h1>cat index</h1>
+            """
+        Given I have a "public/cat/cat.html" file with the body:
+            """
+            <h1>cat cat</h1>
+            """
+        Given I have a "public/kitty/cat/index.html" file with the body:
+            """
+            <h1>kitty cat index</h1>
+            """
+        Given I have a "public/cat.html" file with the body:
+            """
+            <h1>cat</h1>
+            """
+        Given I have a "pagefind.yml" file with the content:
+            """
+            glob: "{cat/index.htm,kitty/**/*.html,cat.html}"
+            """
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "public/_pagefind/pagefind.js"
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/_pagefind/pagefind.js");
+
+                let search = await pagefind.search("cat");
+
+                let pages = await Promise.all(search.results.map(r => r.data()));
+                document.querySelector('[data-result]').innerText = pages.map(p => p.url).sort().join(", ");
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-result]" should contain "/cat.html, /cat/index.htm, /kitty/cat/"

--- a/pagefind/features/frozen-pre-1.0/config_sources.feature
+++ b/pagefind/features/frozen-pre-1.0/config_sources.feature
@@ -1,0 +1,96 @@
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# This file represents a backwards-compatible setup as it existed before 1.0  #
+# These tests should remain as a permanent regresison check for older sites   #
+# It is very unlikely that the tests in this file should be touched           #
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+Feature: Config Sources
+
+    Scenario: Settings can be pulled from TOML configuration files
+        Given I have a "public/index.html" file with the body:
+            """
+            <link rel="pre-1.0-signal" href="_pagefind" >
+            <h1>Hello.</h1>
+            """
+        Given I have a "pagefind.toml" file with the content:
+            """
+            source = "public"
+            """
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "public/_pagefind/pagefind.js"
+
+    Scenario: Settings can be pulled from YAML configuration files
+        Given I have a "public/index.html" file with the body:
+            """
+            <link rel="pre-1.0-signal" href="_pagefind" >
+            <h1>Hello.</h1>
+            """
+        Given I have a "pagefind.yml" file with the content:
+            """
+            source: public
+            """
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "public/_pagefind/pagefind.js"
+
+    Scenario: Settings can be pulled from JSON configuration files
+        Given I have a "public/index.html" file with the body:
+            """
+            <link rel="pre-1.0-signal" href="_pagefind" >
+            <h1>Hello.</h1>
+            """
+        Given I have a "pagefind.json" file with the content:
+            """
+            {
+                "source": "public"
+            }
+            """
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "public/_pagefind/pagefind.js"
+
+    Scenario: Settings can be pulled from command-line flags
+        Given I have a "public/index.html" file with the body:
+            """
+            <link rel="pre-1.0-signal" href="_pagefind" >
+            <h1>Hello.</h1>
+            """
+        When I run my program with the flags:
+            | --source public |
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "public/_pagefind/pagefind.js"
+
+    Scenario: Settings can be pulled from environment variables
+        Given I have a "public/index.html" file with the body:
+            """
+            <link rel="pre-1.0-signal" href="_pagefind" >
+            <h1>Hello.</h1>
+            """
+        Given I have the environment variables:
+            | PAGEFIND_SOURCE | public |
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "public/_pagefind/pagefind.js"
+
+    Scenario: Settings can be pulled from multiple sources
+        Given I have a "public/index.html" file with the body:
+            """
+            <link rel="pre-1.0-signal" href="_pagefind" >
+            <h1>Hello.</h1>
+            """
+        Given I have a "pagefind.json" file with the content:
+            """
+            {
+                "source": "public"
+            }
+            """
+        When I run my program with the flags:
+            | --bundle-dir _out |
+        Then I should see "Running Pagefind" in stdout
+        Then I should see the file "public/_out/pagefind.js"

--- a/pagefind/features/frozen-pre-1.0/modular_ui/modular_ui_base.feature
+++ b/pagefind/features/frozen-pre-1.0/modular_ui/modular_ui_base.feature
@@ -1,0 +1,67 @@
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# This file represents a backwards-compatible setup as it existed before 1.0  #
+# These tests should remain as a permanent regresison check for older sites   #
+# It is very unlikely that the tests in this file should be touched           #
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+Feature: Base Modular UI Tests
+    Background:
+        Given I have the environment variables:
+            | PAGEFIND_SOURCE | public |
+        Given I have a "public/index.html" file with the body:
+            """
+            <div id="search"></div>
+            <div id="summary"></div>
+            <div id="results"></div>
+            <script src="/_pagefind/pagefind-modular-ui.js"></script>
+
+            <script>
+                window.pagefind = new PagefindModularUI.Instance();
+                pagefind.add(new PagefindModularUI.Input({
+                    containerElement: "#search"
+                }));
+                pagefind.add(new PagefindModularUI.Summary({
+                    containerElement: "#summary"
+                }));
+                pagefind.add(new PagefindModularUI.ResultList({
+                    containerElement: "#results"
+                }));
+            </script>
+            """
+
+    Scenario: Pagefind Modular UI loads
+        Given I have a "public/cat/index.html" file with the body:
+            """
+            <h1>world</h1>
+            """
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "public/_pagefind/pagefind.js"
+        When I serve the "public" directory
+        When I load "/"
+        Then There should be no logs
+        Then The selector "#search input" should exist
+
+    Scenario: Pagefind Modular UI searches
+        Given I have a "public/cat/index.html" file with the body:
+            """
+            <h1>world</h1>
+            """
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "public/_pagefind/pagefind.js"
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let e = new Event('input', {bubbles:true, cancelable:true});
+                document.querySelector("#search input").value = "world";
+                document.querySelector("#search input").dispatchEvent(e);
+                await new Promise(r => setTimeout(r, 1500)); // TODO: await el in humane
+            }
+            """
+        Then There should be no logs
+        Then The selector ".pagefind-modular-list-link" should contain "world"

--- a/pagefind/features/frozen-pre-1.0/multilingual.feature
+++ b/pagefind/features/frozen-pre-1.0/multilingual.feature
@@ -1,0 +1,291 @@
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# This file represents a backwards-compatible setup as it existed before 1.0  #
+# These tests should remain as a permanent regresison check for older sites   #
+# It is very unlikely that the tests in this file should be touched           #
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+Feature: Multilingual
+    Background:
+        Given I have the environment variables:
+            | PAGEFIND_SOURCE | public |
+        Given I have a "public/en/index.html" file with the content:
+            """
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <title>Document</title>
+                    <link rel="pre-1.0-signal" href="_pagefind" >
+                </head>
+                <body>
+                    <p>I am some English documentation</p>
+                </body>
+            </html>
+            """
+        Given I have a "public/pt-br/index.html" file with the content:
+            """
+            <!DOCTYPE html>
+            <html lang="pt-br">
+                <head>
+                    <title>Document</title>
+                </head>
+                <body>
+                    <p>I am a Portuguese document (trust me — quilométricas — see?)</p>
+                </body>
+            </html>
+            """
+
+    Scenario: Pagefind searches for English with English stemming
+        Given I have a "public/index.html" file with the content:
+            """
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <title>Document</title>
+
+                </head>
+                <body>
+                    <p data-result>Nothing</p>
+                </body>
+            </html>
+            """
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/_pagefind/wasm.unknown.pagefind"
+        Then I should see the file "public/_pagefind/wasm.en.pagefind"
+        Then I should see "en" in "public/_pagefind/pagefind-entry.json"
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/_pagefind/pagefind.js");
+
+                let search = await pagefind.search("documenting");
+
+                let data = search.results[0] ? await search.results[0].data() : "None";
+                document.querySelector('[data-result]').innerText = `${search.results.length} — ${data.url}`;
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-result]" should contain "1 — /en/"
+
+    Scenario: Pagefind searches for Portugese with Portugese stemming
+        Given I have a "public/index.html" file with the content:
+            """
+            <!DOCTYPE html>
+            <html lang="pt-br">
+                <head>
+                    <title>Document</title>
+                </head>
+                <body>
+                    <p data-result>Nothing</p>
+                </body>
+            </html>
+            """
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/_pagefind/wasm.unknown.pagefind"
+        Then I should see the file "public/_pagefind/wasm.pt-br.pagefind"
+        Then I should see "pt-br" in "public/_pagefind/pagefind-entry.json"
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/_pagefind/pagefind.js");
+
+                let search = await pagefind.search("quilométricos");
+
+                let data = search.results[0] ? await search.results[0].data() : "None";
+                document.querySelector('[data-result]').innerText = `${search.results.length} — ${data.url}`;
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-result]" should contain "1 — /pt-br/"
+
+    Scenario: Pagefind keeps dialects separate
+        Given I have a "public/pt-pt/index.html" file with the content:
+            """
+            <!DOCTYPE html>
+            <html lang="pt-pt">
+                <head>
+                    <title>Document</title>
+                </head>
+                <body>
+                    <p>I am a different Portugese document (trust me — quilométricas — see?)</p>
+                </body>
+            </html>
+            """
+        Given I have a "public/index.html" file with the content:
+            """
+            <!DOCTYPE html>
+            <html lang="pt-br">
+                <head>
+                    <title>Document</title>
+                </head>
+                <body>
+                    <p data-result>Nothing</p>
+                </body>
+            </html>
+            """
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/_pagefind/wasm.unknown.pagefind"
+        Then I should see the file "public/_pagefind/wasm.pt-pt.pagefind"
+        Then I should see the file "public/_pagefind/wasm.pt-br.pagefind"
+        Then I should see "pt-pt" in "public/_pagefind/pagefind-entry.json"
+        Then I should see "pt-br" in "public/_pagefind/pagefind-entry.json"
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/_pagefind/pagefind.js");
+
+                let search = await pagefind.search("quilométricos");
+
+                let data = search.results[0] ? await search.results[0].data() : "None";
+                document.querySelector('[data-result]').innerText = `${search.results.length} — ${data.url}`;
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-result]" should contain "1 — /pt-br/"
+
+    Scenario: Pagefind can be configured to lump all languages together
+        Given I have a "public/index.html" file with the content:
+            """
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <title>Document</title>
+                </head>
+                <body>
+                    <p data-result>Nothing</p>
+                </body>
+            </html>
+            """
+        When I run my program with the flags:
+            | --force-language "en" |
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/_pagefind/wasm.unknown.pagefind"
+        Then I should see the file "public/_pagefind/wasm.en.pagefind"
+        Then I should not see the file "public/_pagefind/wasm.pt-br.pagefind"
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/_pagefind/pagefind.js");
+
+                let search = await pagefind.search("documenting");
+
+                let data = await Promise.all(search.results.map(result => result.data()));
+                document.querySelector('[data-result]').innerText = `${search.results.length} — ${data.map(d => d.url).sort().join(', ')}`;
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-result]" should contain "2 — /en/, /pt-br/"
+
+    Scenario: Pagefind merges omitted languages into the primary language
+        Given I have a "public/index.html" file with the content:
+            """
+            <!DOCTYPE html>
+            <html>
+                <head>
+                    <title>Document</title>
+                </head>
+                <body>
+                    <p data-result>Nothing</p>
+                </body>
+            </html>
+            """
+        Given I have a "public/mystery/index.html" file with the content:
+            """
+            <!DOCTYPE html>
+            <html>
+                <head>
+                    <title>Document</title>
+                </head>
+                <body>
+                    <p>I am a mystery document</p>
+                </body>
+            </html>
+            """
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/_pagefind/wasm.unknown.pagefind"
+        Then I should not see "unknown" in "public/_pagefind/pagefind-entry.json"
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/_pagefind/pagefind.js");
+
+                let search = await pagefind.search("documenting");
+
+                let data = await Promise.all(search.results.map(result => result.data()));
+                document.querySelector('[data-result]').innerText = `${data.map(d => d.url).sort().join(', ')}`;
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-result]" should contain "/en/, /mystery/"
+
+    Scenario: Pagefind searches for unknown languages with no stemming
+        Given I have a "public/index.html" file with the content:
+            """
+            <!DOCTYPE html>
+            <html lang="my_cool_language">
+                <head>
+                    <title>Document</title>
+                </head>
+                <body>
+                    <p data-result>Nothing</p>
+                </body>
+            </html>
+            """
+        Given I have a "public/mystery/index.html" file with the content:
+            """
+            <!DOCTYPE html>
+            <html lang="my_cool_language">
+                <head>
+                    <title>Document</title>
+                </head>
+                <body>
+                    <p>I am a documentation</p>
+                </body>
+            </html>
+            """
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/_pagefind/wasm.unknown.pagefind"
+        Then I should not see the file "public/_pagefind/wasm.my_cool_language.pagefind"
+        Then I should see "my_cool_language" in "public/_pagefind/pagefind-entry.json"
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/_pagefind/pagefind.js");
+
+                let search = await pagefind.search("documentation");
+                let stem_search = await pagefind.search("documenting");
+
+                let data = search.results[0] ? await search.results[0].data() : "None";
+                document.querySelector('[data-result]').innerText = `${search.results.length} — ${data.url} — ${stem_search.results.length}`;
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-result]" should contain "1 — /mystery/ — 0"

--- a/pagefind/features/frozen-pre-1.0/multisite/multisite_base.feature
+++ b/pagefind/features/frozen-pre-1.0/multisite/multisite_base.feature
@@ -1,0 +1,87 @@
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# This file represents a backwards-compatible setup as it existed before 1.0  #
+# These tests should remain as a permanent regresison check for older sites   #
+# It is very unlikely that the tests in this file should be touched           #
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+Feature: Multisite Search
+
+    Background:
+        Given I have a "root/index.html" file with the body:
+            """
+            <p data-result>Nothing</p>
+            """
+        Given I have a "root/website_a/hello/index.html" file with the body:
+            """
+            <link rel="pre-1.0-signal" href="_pagefind" >
+            <h1>web web world PAGEFIND_ROOT_SELECTOR</h1>
+            """
+        Given I have a "root/website_b/lorem/index.html" file with the body:
+            """
+            <link rel="pre-1.0-signal" href="_pagefind" >
+            <h1>web ipsum</h1>
+            """
+
+    Scenario: Pagefind can search across multiple sites
+        When I run my program with the flags:
+            | --source root/website_a |
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "root/website_a/_pagefind/pagefind.js"
+        When I run my program with the flags:
+            | --source root/website_b |
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "root/website_b/_pagefind/pagefind.js"
+        When I serve the "root" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/website_a/_pagefind/pagefind.js");
+                await pagefind.mergeIndex("/website_b/_pagefind/");
+
+                let search = await pagefind.search("web");
+
+                let pages = await Promise.all(search.results.map(r => r.data()));
+                document.querySelector('[data-result]').innerText = pages.map(p => p.url).join(", ");
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-result]" should contain "/website_a/hello/, /website_b/lorem/"
+
+    Scenario: Pagefind UI can search across multiple sites
+        Given I have a "root/index.html" file with the body:
+            """
+            <div id="search"></div>
+            <script src="/website_a/_pagefind/pagefind-ui.js"></script>
+            """
+        When I run my program with the flags:
+            | --source root/website_a |
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "root/website_a/_pagefind/pagefind.js"
+        When I run my program with the flags:
+            | --source root/website_b |
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "root/website_b/_pagefind/pagefind.js"
+        When I serve the "root" directory
+        When I load "/"
+        Then There should be no logs
+        When I evaluate:
+            """
+            async function() {
+                let pui = new PagefindUI({
+                    element: "#search",
+                    mergeIndex: [{
+                        bundlePath: "/website_b/_pagefind/"
+                    }]
+                });
+                pui.triggerSearch("web");
+                await new Promise(r => setTimeout(r, 3500)); // TODO: await el in humane
+            }
+            """
+        Then There should be no logs
+        Then The selector ".pagefind-ui__result:nth-of-type(1) .pagefind-ui__result-link" should contain "web web world PAGEFIND_ROOT_SELECTOR"
+        Then The selector ".pagefind-ui__result:nth-of-type(2) .pagefind-ui__result-link" should contain "web ipsum"

--- a/pagefind/features/frozen-pre-1.0/sanity.feature
+++ b/pagefind/features/frozen-pre-1.0/sanity.feature
@@ -1,0 +1,28 @@
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# This file represents a backwards-compatible setup as it existed before 1.0  #
+# These tests should remain as a permanent regresison check for older sites   #
+# It is very unlikely that the tests in this file should be touched           #
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+Feature: Sanity Tests
+
+  Scenario: CLI tests are working
+    Given I have a "public/index.html" file with the body:
+      """
+        <link rel="pre-1.0-signal" href="_pagefind" >
+        <p data-url>Nothing</p>
+      """
+    When I run my program with the flags:
+      | --source public |
+    Then I should see "Running Pagefind" in stdout
+    Then I should see "pre-1.0 compatibility mode" in stderr
+    Then I should see "The `source` option is deprecated" in stderr
+
+  Scenario: Web tests are working
+    Given I have a "public/index.html" file with the body:
+      """
+      <h1>Hello!</h1>
+      """
+    When I serve the "public" directory
+    When I load "/"
+    Then The selector "h1" should contain "Hello!"

--- a/pagefind/features/frozen-pre-1.0/search_options.feature
+++ b/pagefind/features/frozen-pre-1.0/search_options.feature
@@ -1,0 +1,105 @@
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# This file represents a backwards-compatible setup as it existed before 1.0  #
+# These tests should remain as a permanent regresison check for older sites   #
+# It is very unlikely that the tests in this file should be touched           #
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+Feature: Search Options
+
+    Background:
+        Given I have the environment variables:
+            | PAGEFIND_SOURCE | public |
+
+    Scenario: Base URL can be configured
+        Given I have a "public/index.html" file with the body:
+            """
+            <link rel="pre-1.0-signal" href="_pagefind" >
+            <p data-url>Nothing</p>
+            """
+        Given I have a "public/cat/index.html" file with the body:
+            """
+            <h1>world</h1>
+            """
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "public/_pagefind/pagefind.js"
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/_pagefind/pagefind.js");
+                await pagefind.options({
+                    baseUrl: "/docs/"
+                });
+
+                let search = await pagefind.search("world");
+
+                let data = await search.results[0].data();
+                document.querySelector('[data-url]').innerText = data.url;
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-url]" should contain "/docs/cat/"
+
+    Scenario: Base URL auto-detects the default directory being moved
+        Given I have a "public/index.html" file with the body:
+            """
+            <link rel="pre-1.0-signal" href="_pagefind" >
+            <p data-url>Nothing</p>
+            """
+        Given I have a "public/cat/index.html" file with the body:
+            """
+            <h1>world</h1>
+            """
+        When I run my program with the flags:
+            | --bundle-dir blog/_pagefind |
+        Then I should see "Running Pagefind" in stdout
+        Then I should see the file "public/blog/_pagefind/pagefind.js"
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/blog/_pagefind/pagefind.js");
+
+                let search = await pagefind.search("world");
+
+                let data = await search.results[0].data();
+                document.querySelector('[data-url]').innerText = data.url;
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-url]" should contain "/blog/cat/"
+
+    Scenario: Keep Index URL can be configured
+        Given I have a "public/index.html" file with the body:
+            """
+            <link rel="pre-1.0-signal" href="_pagefind" >
+            <p data-url>Nothing</p>
+            """
+        Given I have a "public/cat/index.html" file with the body:
+            """
+            <h1>world</h1>
+            """
+        When I run my program with the flags:
+            | --bundle-dir blog/_pagefind |
+            | --keep-index-url            |
+        Then I should see "Running Pagefind" in stdout
+        Then I should see the file "public/blog/_pagefind/pagefind.js"
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/blog/_pagefind/pagefind.js");
+
+                let search = await pagefind.search("world");
+
+                let data = await search.results[0].data();
+                document.querySelector('[data-url]').innerText = data.url;
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-url]" should contain "/blog/cat/index.html"

--- a/pagefind/features/frozen-pre-1.0/ui/ui_base.feature
+++ b/pagefind/features/frozen-pre-1.0/ui/ui_base.feature
@@ -1,0 +1,54 @@
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# This file represents a backwards-compatible setup as it existed before 1.0  #
+# These tests should remain as a permanent regresison check for older sites   #
+# It is very unlikely that the tests in this file should be touched           #
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+Feature: Base UI Tests
+    Background:
+        Given I have the environment variables:
+            | PAGEFIND_SOURCE | public |
+        Given I have a "public/index.html" file with the body:
+            """
+            <div id="search"></div>
+            <script src="/_pagefind/pagefind-ui.js"></script>
+
+            <script>
+                window.pui = new PagefindUI({ element: "#search" });
+            </script>
+            """
+
+    Scenario: Pagefind UI loads
+        Given I have a "public/cat/index.html" file with the body:
+            """
+            <h1>world</h1>
+            """
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "public/_pagefind/pagefind.js"
+        When I serve the "public" directory
+        When I load "/"
+        Then There should be no logs
+        Then The selector ".pagefind-ui" should exist
+
+    Scenario: Pagefind UI searches
+        Given I have a "public/cat/index.html" file with the body:
+            """
+            <h1>world</h1>
+            """
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        Then I should see "pre-1.0 compatibility mode" in stderr
+        Then I should see the file "public/_pagefind/pagefind.js"
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                window.pui.triggerSearch("world");
+                await new Promise(r => setTimeout(r, 1500)); // TODO: await el in humane
+            }
+            """
+        Then There should be no logs
+        Then The selector ".pagefind-ui__result-link" should contain "world"

--- a/pagefind/features/index_chunking.feature
+++ b/pagefind/features/index_chunking.feature
@@ -2,7 +2,7 @@ Feature: Index Chunking
 
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
         Given I have a "public/index.html" file with the body:
             """
             <ul>
@@ -20,13 +20,13 @@ Feature: Index Chunking
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("h");
 

--- a/pagefind/features/indexing.feature
+++ b/pagefind/features/indexing.feature
@@ -2,7 +2,7 @@ Feature: Indexing
 
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
 
     Scenario: Indexing can be limited to a given element
         Given I have a "public/index.html" file with the body:
@@ -41,7 +41,7 @@ Feature: Indexing
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let searchone = await pagefind.search("hello");
                 let searchonedata = await searchone.results[0].data();
@@ -73,7 +73,7 @@ Feature: Indexing
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("Alternate");
                 let searchdata = await search.results[0]?.data();

--- a/pagefind/features/input_quirks.feature
+++ b/pagefind/features/input_quirks.feature
@@ -1,7 +1,7 @@
 Feature: Input Quirk Tests
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE  | public |
+            | PAGEFIND_SITE    | public |
             | PAGEFIND_verbose | true   |
         Given I have a "public/index.html" file with the body:
             """
@@ -15,13 +15,13 @@ Feature: Input Quirk Tests
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("world");
 

--- a/pagefind/features/metadata.feature
+++ b/pagefind/features/metadata.feature
@@ -1,7 +1,7 @@
 Feature: Metadata
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
         Given I have a "public/index.html" file with the content:
             """
             <html>
@@ -73,7 +73,7 @@ Feature: Metadata
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
 
@@ -81,7 +81,7 @@ Feature: Metadata
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("cat");
 
@@ -98,7 +98,7 @@ Feature: Metadata
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("feline");
 
@@ -113,7 +113,7 @@ Feature: Metadata
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("feline");
 
@@ -129,7 +129,7 @@ Feature: Metadata
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("cat");
 
@@ -144,7 +144,7 @@ Feature: Metadata
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("cat");
 
@@ -159,7 +159,7 @@ Feature: Metadata
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("cat");
 
@@ -174,7 +174,7 @@ Feature: Metadata
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("dog");
 
@@ -195,7 +195,7 @@ Feature: Metadata
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("NZ");
 

--- a/pagefind/features/modular_ui/modular_ui_base.feature
+++ b/pagefind/features/modular_ui/modular_ui_base.feature
@@ -1,13 +1,13 @@
 Feature: Base Modular UI Tests
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
         Given I have a "public/index.html" file with the body:
             """
             <div id="search"></div>
             <div id="summary"></div>
             <div id="results"></div>
-            <script src="/_pagefind/pagefind-modular-ui.js"></script>
+            <script src="/pagefind/pagefind-modular-ui.js"></script>
 
             <script>
                 window.pagefind = new PagefindModularUI.Instance();
@@ -30,7 +30,7 @@ Feature: Base Modular UI Tests
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         Then There should be no logs
@@ -43,7 +43,7 @@ Feature: Base Modular UI Tests
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:

--- a/pagefind/features/multilingual.feature
+++ b/pagefind/features/multilingual.feature
@@ -1,7 +1,7 @@
 Feature: Multilingual
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
         Given I have a "public/en/index.html" file with the content:
             """
             <!DOCTYPE html>
@@ -42,16 +42,16 @@ Feature: Multilingual
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
-        Then I should see the file "public/_pagefind/wasm.unknown.pagefind"
-        Then I should see the file "public/_pagefind/wasm.en.pagefind"
-        Then I should see "en" in "public/_pagefind/pagefind-entry.json"
+        Then I should see the file "public/pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/wasm.unknown.pagefind"
+        Then I should see the file "public/pagefind/wasm.en.pagefind"
+        Then I should see "en" in "public/pagefind/pagefind-entry.json"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("documenting");
 
@@ -77,16 +77,16 @@ Feature: Multilingual
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
-        Then I should see the file "public/_pagefind/wasm.unknown.pagefind"
-        Then I should see the file "public/_pagefind/wasm.pt-br.pagefind"
-        Then I should see "pt-br" in "public/_pagefind/pagefind-entry.json"
+        Then I should see the file "public/pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/wasm.unknown.pagefind"
+        Then I should see the file "public/pagefind/wasm.pt-br.pagefind"
+        Then I should see "pt-br" in "public/pagefind/pagefind-entry.json"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("quilométricos");
 
@@ -124,18 +124,18 @@ Feature: Multilingual
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
-        Then I should see the file "public/_pagefind/wasm.unknown.pagefind"
-        Then I should see the file "public/_pagefind/wasm.pt-pt.pagefind"
-        Then I should see the file "public/_pagefind/wasm.pt-br.pagefind"
-        Then I should see "pt-pt" in "public/_pagefind/pagefind-entry.json"
-        Then I should see "pt-br" in "public/_pagefind/pagefind-entry.json"
+        Then I should see the file "public/pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/wasm.unknown.pagefind"
+        Then I should see the file "public/pagefind/wasm.pt-pt.pagefind"
+        Then I should see the file "public/pagefind/wasm.pt-br.pagefind"
+        Then I should see "pt-pt" in "public/pagefind/pagefind-entry.json"
+        Then I should see "pt-br" in "public/pagefind/pagefind-entry.json"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("quilométricos");
 
@@ -162,16 +162,16 @@ Feature: Multilingual
         When I run my program with the flags:
             | --force-language "en" |
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
-        Then I should see the file "public/_pagefind/wasm.unknown.pagefind"
-        Then I should see the file "public/_pagefind/wasm.en.pagefind"
-        Then I should not see the file "public/_pagefind/wasm.pt-br.pagefind"
+        Then I should see the file "public/pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/wasm.unknown.pagefind"
+        Then I should see the file "public/pagefind/wasm.en.pagefind"
+        Then I should not see the file "public/pagefind/wasm.pt-br.pagefind"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("documenting");
 
@@ -209,15 +209,15 @@ Feature: Multilingual
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
-        Then I should see the file "public/_pagefind/wasm.unknown.pagefind"
-        Then I should not see "unknown" in "public/_pagefind/pagefind-entry.json"
+        Then I should see the file "public/pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/wasm.unknown.pagefind"
+        Then I should not see "unknown" in "public/pagefind/pagefind-entry.json"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("documenting");
 
@@ -255,16 +255,16 @@ Feature: Multilingual
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
-        Then I should see the file "public/_pagefind/wasm.unknown.pagefind"
-        Then I should not see the file "public/_pagefind/wasm.my_cool_language.pagefind"
-        Then I should see "my_cool_language" in "public/_pagefind/pagefind-entry.json"
+        Then I should see the file "public/pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/wasm.unknown.pagefind"
+        Then I should not see the file "public/pagefind/wasm.my_cool_language.pagefind"
+        Then I should see "my_cool_language" in "public/pagefind/pagefind-entry.json"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("documentation");
                 let stem_search = await pagefind.search("documenting");

--- a/pagefind/features/multisite/multisite_base.feature
+++ b/pagefind/features/multisite/multisite_base.feature
@@ -14,22 +14,22 @@ Feature: Multisite Search
             <h1>web ipsum</h1>
             """
 
-    Scenario: Pagefind can search across multiple sites
+    Scenario: Pagefind can search across multiple basic sites
         When I run my program with the flags:
-            | --source root/website_a |
+            | --site root/website_a |
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "root/website_a/_pagefind/pagefind.js"
+        Then I should see the file "root/website_a/pagefind/pagefind.js"
         When I run my program with the flags:
-            | --source root/website_b |
+            | --site root/website_b |
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "root/website_b/_pagefind/pagefind.js"
+        Then I should see the file "root/website_b/pagefind/pagefind.js"
         When I serve the "root" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/website_a/_pagefind/pagefind.js");
-                await pagefind.mergeIndex("/website_b/_pagefind/");
+                let pagefind = await import("/website_a/pagefind/pagefind.js");
+                await pagefind.mergeIndex("/website_b/pagefind/");
 
                 let search = await pagefind.search("web");
 
@@ -44,16 +44,16 @@ Feature: Multisite Search
         Given I have a "root/index.html" file with the body:
             """
             <div id="search"></div>
-            <script src="/website_a/_pagefind/pagefind-ui.js"></script>
+            <script src="/website_a/pagefind/pagefind-ui.js"></script>
             """
         When I run my program with the flags:
-            | --source root/website_a |
+            | --site root/website_a |
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "root/website_a/_pagefind/pagefind.js"
+        Then I should see the file "root/website_a/pagefind/pagefind.js"
         When I run my program with the flags:
-            | --source root/website_b |
+            | --site root/website_b |
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "root/website_b/_pagefind/pagefind.js"
+        Then I should see the file "root/website_b/pagefind/pagefind.js"
         When I serve the "root" directory
         When I load "/"
         Then There should be no logs
@@ -63,7 +63,7 @@ Feature: Multisite Search
                 let pui = new PagefindUI({
                     element: "#search",
                     mergeIndex: [{
-                        bundlePath: "/website_b/_pagefind/"
+                        bundlePath: "/website_b/pagefind/"
                     }]
                 });
                 pui.triggerSearch("web");
@@ -79,16 +79,16 @@ Feature: Multisite Search
     @skip
     Scenario: Pagefind can search across discrete domains
         When I run my program with the flags:
-            | --source root/website_a |
+            | --site root/website_a |
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "root/website_a/_pagefind/pagefind.js"
+        Then I should see the file "root/website_a/pagefind/pagefind.js"
         When I serve the "root" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/website_a/_pagefind/pagefind.js");
-                await pagefind.mergeIndex("https://pagefind.app/_pagefind/");
+                let pagefind = await import("/website_a/pagefind/pagefind.js");
+                await pagefind.mergeIndex("https://pagefind.app/pagefind/");
 
                 let search = await pagefind.search("PAGEFIND_ROOT_SELECTOR");
 
@@ -107,12 +107,12 @@ Feature: Multisite Search
         Given I have a "root/index.html" file with the body:
             """
             <div id="search"></div>
-            <script src="/website_a/_pagefind/pagefind-ui.js"></script>
+            <script src="/website_a/pagefind/pagefind-ui.js"></script>
             """
         When I run my program with the flags:
-            | --source root/website_a |
+            | --site root/website_a |
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "root/website_a/_pagefind/pagefind.js"
+        Then I should see the file "root/website_a/pagefind/pagefind.js"
         When I serve the "root" directory
         When I load "/"
         Then There should be no logs
@@ -122,7 +122,7 @@ Feature: Multisite Search
                 let pui = new PagefindUI({
                     element: "#search",
                     mergeIndex: [{
-                        bundlePath: "https://pagefind.app/_pagefind/"
+                        bundlePath: "https://pagefind.app/pagefind/"
                     }]
                 });
                 pui.triggerSearch("PAGEFIND_ROOT_SELECTOR");

--- a/pagefind/features/multisite/multisite_filters.feature
+++ b/pagefind/features/multisite/multisite_filters.feature
@@ -18,13 +18,13 @@ Feature: Multisite Filters
             <span data-pagefind-filter="emote">happy</span>
             """
         When I run my program with the flags:
-            | --source root/website_a |
+            | --site root/website_a |
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "root/website_a/_pagefind/pagefind.js"
+        Then I should see the file "root/website_a/pagefind/pagefind.js"
         When I run my program with the flags:
-            | --source root/website_b |
+            | --site root/website_b |
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "root/website_b/_pagefind/pagefind.js"
+        Then I should see the file "root/website_b/pagefind/pagefind.js"
         When I serve the "root" directory
         When I load "/"
 
@@ -32,8 +32,8 @@ Feature: Multisite Filters
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/website_a/_pagefind/pagefind.js");
-                await pagefind.mergeIndex("/website_b/_pagefind/");
+                let pagefind = await import("/website_a/pagefind/pagefind.js");
+                await pagefind.mergeIndex("/website_b/pagefind/");
 
                 let search = await pagefind.search("web", {
                     filters: {
@@ -52,8 +52,8 @@ Feature: Multisite Filters
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/website_a/_pagefind/pagefind.js");
-                await pagefind.mergeIndex("/website_b/_pagefind/");
+                let pagefind = await import("/website_a/pagefind/pagefind.js");
+                await pagefind.mergeIndex("/website_b/pagefind/");
 
                 let search = await pagefind.search("web", {
                     filters: {
@@ -72,13 +72,13 @@ Feature: Multisite Filters
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/website_a/_pagefind/pagefind.js");
+                let pagefind = await import("/website_a/pagefind/pagefind.js");
                 await pagefind.options({
                     mergeFilter: {
                         site: "A"
                     }
                 });
-                await pagefind.mergeIndex("/website_b/_pagefind/", {
+                await pagefind.mergeIndex("/website_b/pagefind/", {
                     mergeFilter: {
                         site: ["B", "C"]
                     }

--- a/pagefind/features/multisite/multisite_lang.feature
+++ b/pagefind/features/multisite/multisite_lang.feature
@@ -49,20 +49,20 @@ Feature: Multisite Search Languages
 
     Scenario: Pagefind picks the same language across multiple sites
         When I run my program with the flags:
-            | --source root/website_a |
+            | --site root/website_a |
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "root/website_a/_pagefind/pagefind.js"
+        Then I should see the file "root/website_a/pagefind/pagefind.js"
         When I run my program with the flags:
-            | --source root/website_b |
+            | --site root/website_b |
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "root/website_b/_pagefind/pagefind.js"
+        Then I should see the file "root/website_b/pagefind/pagefind.js"
         When I serve the "root" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/website_a/_pagefind/pagefind.js");
-                await pagefind.mergeIndex("/website_b/_pagefind/");
+                let pagefind = await import("/website_a/pagefind/pagefind.js");
+                await pagefind.mergeIndex("/website_b/pagefind/");
 
                 let search = await pagefind.search("web"); // <-- TODO search for "website"
 
@@ -75,20 +75,20 @@ Feature: Multisite Search Languages
 
     Scenario: Language of merged indexes can be selected
         When I run my program with the flags:
-            | --source root/website_a |
+            | --site root/website_a |
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "root/website_a/_pagefind/pagefind.js"
+        Then I should see the file "root/website_a/pagefind/pagefind.js"
         When I run my program with the flags:
-            | --source root/website_b |
+            | --site root/website_b |
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "root/website_b/_pagefind/pagefind.js"
+        Then I should see the file "root/website_b/pagefind/pagefind.js"
         When I serve the "root" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/website_a/_pagefind/pagefind.js");
-                await pagefind.mergeIndex("/website_b/_pagefind/", {
+                let pagefind = await import("/website_a/pagefind/pagefind.js");
+                await pagefind.mergeIndex("/website_b/pagefind/", {
                     language: "pt-br"
                 });
 

--- a/pagefind/features/multisite/multisite_sort.feature
+++ b/pagefind/features/multisite/multisite_sort.feature
@@ -20,20 +20,20 @@ Feature: Multisite Result Scoring
 
     Scenario: Pages are scored correctly across indexes
         When I run my program with the flags:
-            | --source root/website_a |
+            | --site root/website_a |
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "root/website_a/_pagefind/pagefind.js"
+        Then I should see the file "root/website_a/pagefind/pagefind.js"
         When I run my program with the flags:
-            | --source root/website_b |
+            | --site root/website_b |
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "root/website_b/_pagefind/pagefind.js"
+        Then I should see the file "root/website_b/pagefind/pagefind.js"
         When I serve the "root" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/website_a/_pagefind/pagefind.js");
-                await pagefind.mergeIndex("/website_b/_pagefind/");
+                let pagefind = await import("/website_a/pagefind/pagefind.js");
+                await pagefind.mergeIndex("/website_b/pagefind/");
 
                 let search = await pagefind.search("web");
 
@@ -46,20 +46,20 @@ Feature: Multisite Result Scoring
 
     Scenario: Multiple indexes can be weighted separately
         When I run my program with the flags:
-            | --source root/website_a |
+            | --site root/website_a |
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "root/website_a/_pagefind/pagefind.js"
+        Then I should see the file "root/website_a/pagefind/pagefind.js"
         When I run my program with the flags:
-            | --source root/website_b |
+            | --site root/website_b |
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "root/website_b/_pagefind/pagefind.js"
+        Then I should see the file "root/website_b/pagefind/pagefind.js"
         When I serve the "root" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/website_a/_pagefind/pagefind.js");
-                await pagefind.mergeIndex("/website_b/_pagefind/", {
+                let pagefind = await import("/website_a/pagefind/pagefind.js");
+                await pagefind.mergeIndex("/website_b/pagefind/", {
                     indexWeight: 2
                 });
 

--- a/pagefind/features/node_api/node_base.feature
+++ b/pagefind/features/node_api/node_base.feature
@@ -34,13 +34,13 @@ Feature: Node API Base Tests
 #             """
 #         When I run "cd public && npm i && PAGEFIND_BINARY_PATH='{{humane_cwd}}/../target/release/pagefind' node index.js"
 #         Then I should see "Successfully wrote files" in stdout
-#         Then I should see the file "public/_pagefind/pagefind.js"
+#         Then I should see the file "public/pagefind/pagefind.js"
 #         When I serve the "public" directory
 #         When I load "/"
 #         When I evaluate:
 #             """
 #             async function() {
-#                 let pagefind = await import("/_pagefind/pagefind.js");
+#                 let pagefind = await import("/pagefind/pagefind.js");
 
 #                 let search = await pagefind.search("testing");
 
@@ -74,7 +74,7 @@ Feature: Node API Base Tests
 #         When I run "cd public && npm i && PAGEFIND_BINARY_PATH='{{humane_cwd}}/../target/release/pagefind' node index.js"
 #         Then I should see "pagefind_version=" in stdout
 #         Then I should see "1 fragment(s)" in stdout
-#         Then I should not see the file "public/_pagefind/pagefind.js"
+#         Then I should not see the file "public/pagefind/pagefind.js"
 
 #     @platform-unix
 #     Scenario: Build a true index to disk via the api
@@ -97,13 +97,13 @@ Feature: Node API Base Tests
 #             """
 #         When I run "cd public && npm i && PAGEFIND_BINARY_PATH='{{humane_cwd}}/../target/release/pagefind' node index.js"
 #         Then I should see "Successfully wrote files" in stdout
-#         Then I should see the file "public/_pagefind/pagefind.js"
+#         Then I should see the file "public/pagefind/pagefind.js"
 #         When I serve the "public" directory
 #         When I load "/"
 #         When I evaluate:
 #             """
 #             async function() {
-#                 let pagefind = await import("/_pagefind/pagefind.js");
+#                 let pagefind = await import("/pagefind/pagefind.js");
 
 #                 let search = await pagefind.search("testing");
 
@@ -151,13 +151,13 @@ Feature: Node API Base Tests
 #             """
 #         When I run "cd public && npm i && PAGEFIND_BINARY_PATH='{{humane_cwd}}/../target/release/pagefind' node index.js"
 #         Then I should see "Donezo!" in stdout
-#         Then I should see the file "public/_pagefind/pagefind.js"
+#         Then I should see the file "public/pagefind/pagefind.js"
 #         When I serve the "public" directory
 #         When I load "/"
 #         When I evaluate:
 #             """
 #             async function() {
-#                 let pagefind = await import("/_pagefind/pagefind.js");
+#                 let pagefind = await import("/pagefind/pagefind.js");
 
 #                 let search = await pagefind.search("testing");
 
@@ -181,7 +181,7 @@ Feature: Node API Base Tests
 #             const run = async () => {
 #                 const { index } = await pagefind.createIndex();
 #                 await index.addHTMLFile({path: "dogs/index.html", content: "<html><body><h1>Testing, testing</h1></body></html>"});
-#                 await index.writeFiles({ bundlePath: "../output/_pagefind" });
+#                 await index.writeFiles({ bundlePath: "../output/pagefind" });
 #                 console.log(`Successfully wrote files`);
 #             }
 
@@ -189,13 +189,13 @@ Feature: Node API Base Tests
 #             """
 #         When I run "cd public && npm i && PAGEFIND_BINARY_PATH='{{humane_cwd}}/../target/release/pagefind' node index.js"
 #         Then I should see "Successfully wrote files" in stdout
-#         Then I should see the file "output/_pagefind/pagefind.js"
+#         Then I should see the file "output/pagefind/pagefind.js"
 #         When I serve the "output" directory
 #         When I load "/"
 #         When I evaluate:
 #             """
 #             async function() {
-#                 let pagefind = await import("/_pagefind/pagefind.js");
+#                 let pagefind = await import("/pagefind/pagefind.js");
 
 #                 let search = await pagefind.search("testing");
 
@@ -219,7 +219,7 @@ Feature: Node API Base Tests
 #             const run = async () => {
 #                 const { index } = await pagefind.createIndex();
 #                 await index.addHTMLFile({path: "dogs/index.html", content: "<html><body><h1>Testing, testing</h1></body></html>"});
-#                 await index.writeFiles({ bundlePath: "../output/_pagefind" });
+#                 await index.writeFiles({ bundlePath: "../output/pagefind" });
 
 #                 await index.addHTMLFile({path: "rabbits/index.html", content: "<html><body><h1>Testing, testing</h1></body></html>"});
 #                 const { files } = await index.getFiles();
@@ -228,7 +228,7 @@ Feature: Node API Base Tests
 #                 console.log(`${fragments.length} fragment(s)`);
 
 #                 await index.addHTMLFile({path: "cats/index.html", content: "<html><body><h1>Testing, testing</h1></body></html>"});
-#                 await index.writeFiles({ bundlePath: "./_pagefind" });
+#                 await index.writeFiles({ bundlePath: "./pagefind" });
 
 #                 console.log(`Successfully wrote files`);
 #             }
@@ -238,13 +238,13 @@ Feature: Node API Base Tests
 #         When I run "cd public && npm i && PAGEFIND_BINARY_PATH='{{humane_cwd}}/../target/release/pagefind' node index.js"
 #         Then I should see "Successfully wrote files" in stdout
 #         Then I should see "2 fragment(s)" in stdout
-#         Then I should see the file "output/_pagefind/pagefind.js"
+#         Then I should see the file "output/pagefind/pagefind.js"
 #         When I serve the "output" directory
 #         When I load "/"
 #         When I evaluate:
 #             """
 #             async function() {
-#                 let pagefind = await import("/_pagefind/pagefind.js");
+#                 let pagefind = await import("/pagefind/pagefind.js");
 
 #                 let search = await pagefind.search("testing");
 
@@ -259,7 +259,7 @@ Feature: Node API Base Tests
 #         When I evaluate:
 #             """
 #             async function() {
-#                 let pagefind = await import("/_pagefind/pagefind.js");
+#                 let pagefind = await import("/pagefind/pagefind.js");
 
 #                 let search = await pagefind.search("testing");
 
@@ -291,13 +291,13 @@ Feature: Node API Base Tests
 #             """
 #         When I run "cd public && npm i && PAGEFIND_BINARY_PATH='{{humane_cwd}}/../target/release/pagefind' node index.js"
 #         Then I should see "Successfully wrote files" in stdout
-#         Then I should see the file "public/_pagefind/pagefind.js"
+#         Then I should see the file "public/pagefind/pagefind.js"
 #         When I serve the "public" directory
 #         When I load "/"
 #         When I evaluate:
 #             """
 #             async function() {
-#                 let pagefind = await import("/_pagefind/pagefind.js");
+#                 let pagefind = await import("/pagefind/pagefind.js");
 
 #                 let search = await pagefind.search("testing");
 

--- a/pagefind/features/partial_matching.feature
+++ b/pagefind/features/partial_matching.feature
@@ -2,7 +2,7 @@ Feature: Partial Matching
 
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
 
     @skip
     Scenario: Search will return pages that match 2 out of 3 words
@@ -12,13 +12,13 @@ Feature: Partial Matching
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("hello there world");
 

--- a/pagefind/features/sanity.feature
+++ b/pagefind/features/sanity.feature
@@ -3,7 +3,7 @@ Feature: Sanity Tests
   Scenario: CLI tests are working
     Given I have a "public/index.html" file
     When I run my program with the flags:
-      | --source public |
+      | --site public |
     Then I should see "Running Pagefind" in stdout
 
   Scenario: Web tests are working

--- a/pagefind/features/scoring.feature
+++ b/pagefind/features/scoring.feature
@@ -1,7 +1,7 @@
 Feature: Result Scoring
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
         Given I have a "public/index.html" file with the body:
             """
             <ul>
@@ -26,7 +26,7 @@ Feature: Result Scoring
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search(`cat`);
 
@@ -41,7 +41,7 @@ Feature: Result Scoring
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search(`dog`);
 
@@ -59,7 +59,7 @@ Feature: Result Scoring
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search(`cats dogs`);
 
@@ -74,7 +74,7 @@ Feature: Result Scoring
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search(`cats posts`);
 

--- a/pagefind/features/search_options.feature
+++ b/pagefind/features/search_options.feature
@@ -2,7 +2,7 @@ Feature: Search Options
 
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
 
     Scenario: Base URL can be configured
         Given I have a "public/index.html" file with the body:
@@ -15,13 +15,13 @@ Feature: Search Options
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
                 await pagefind.options({
                     baseUrl: "/docs/"
                 });
@@ -45,15 +45,15 @@ Feature: Search Options
             <h1>world</h1>
             """
         When I run my program with the flags:
-            | --bundle-dir blog/_pagefind |
+            | --output-subdir blog/pagefind |
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/blog/_pagefind/pagefind.js"
+        Then I should see the file "public/blog/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/blog/_pagefind/pagefind.js");
+                let pagefind = await import("/blog/pagefind/pagefind.js");
 
                 let search = await pagefind.search("world");
 
@@ -74,16 +74,16 @@ Feature: Search Options
             <h1>world</h1>
             """
         When I run my program with the flags:
-            | --bundle-dir blog/_pagefind |
-            | --keep-index-url |
+            | --output-subdir blog/pagefind |
+            | --keep-index-url              |
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/blog/_pagefind/pagefind.js"
+        Then I should see the file "public/blog/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/blog/_pagefind/pagefind.js");
+                let pagefind = await import("/blog/pagefind/pagefind.js");
 
                 let search = await pagefind.search("world");
 

--- a/pagefind/features/sentences.feature
+++ b/pagefind/features/sentences.feature
@@ -1,7 +1,7 @@
 Feature: Sentence Building Tests
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
         Given I have a "public/index.html" file with the body:
             """
             <p data-result>Nothing</p>
@@ -14,13 +14,13 @@ Feature: Sentence Building Tests
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("h");
 
@@ -38,13 +38,13 @@ Feature: Sentence Building Tests
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("h");
 
@@ -62,13 +62,13 @@ Feature: Sentence Building Tests
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("w");
 

--- a/pagefind/features/sorting.feature
+++ b/pagefind/features/sorting.feature
@@ -1,7 +1,7 @@
 Feature: Result Sorting
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
         Given I have a "public/index.html" file with the body:
             """
             <p data-asc></p>
@@ -39,7 +39,7 @@ Feature: Result Sorting
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let asc_search = await pagefind.search("Robe", { sort: { model: "asc" } });
                 let asc_data = await Promise.all(asc_search.results.map(result => result.data()));
@@ -58,7 +58,7 @@ Feature: Result Sorting
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let asc_search = await pagefind.search("Robe", { sort: { lumens: "asc" } });
                 let asc_data = await Promise.all(asc_search.results.map(result => result.data()));
@@ -77,7 +77,7 @@ Feature: Result Sorting
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let asc_search = await pagefind.search("Robe", { sort: { weight: "asc" } });
                 let asc_data = await Promise.all(asc_search.results.map(result => result.data()));
@@ -96,7 +96,7 @@ Feature: Result Sorting
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let asc_search = await pagefind.search("Robe", { sort: { mixed: "asc" } });
                 let asc_data = await Promise.all(asc_search.results.map(result => result.data()));
@@ -115,7 +115,7 @@ Feature: Result Sorting
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let asc_search = await pagefind.search("Robe", { sort: { color: "asc" } });
                 let asc_data = await Promise.all(asc_search.results.map(result => result.data()));

--- a/pagefind/features/stemming.feature
+++ b/pagefind/features/stemming.feature
@@ -1,7 +1,7 @@
 Feature: Word Stemming
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
         Given I have a "public/index.html" file with the body:
             """
             <ul>
@@ -16,13 +16,13 @@ Feature: Word Stemming
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("meowed");
 
@@ -40,13 +40,13 @@ Feature: Word Stemming
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("meOWings");
 
@@ -64,13 +64,13 @@ Feature: Word Stemming
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("usb[a");
 
@@ -88,13 +88,13 @@ Feature: Word Stemming
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("documentation");
 
@@ -112,13 +112,13 @@ Feature: Word Stemming
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("installat");
 

--- a/pagefind/features/suggestions.feature
+++ b/pagefind/features/suggestions.feature
@@ -2,7 +2,7 @@ Feature: Spellcheck
 
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
         Given I have a "public/index.html" file with the body:
             """
             <ul>
@@ -21,13 +21,13 @@ Feature: Spellcheck
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search("w");
 

--- a/pagefind/features/ui/ui_base.feature
+++ b/pagefind/features/ui/ui_base.feature
@@ -1,11 +1,11 @@
 Feature: Base UI Tests
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
         Given I have a "public/index.html" file with the body:
             """
             <div id="search"></div>
-            <script src="/_pagefind/pagefind-ui.js"></script>
+            <script src="/pagefind/pagefind-ui.js"></script>
 
             <script>
                 window.pui = new PagefindUI({ element: "#search" });
@@ -19,7 +19,7 @@ Feature: Base UI Tests
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         Then There should be no logs
@@ -32,7 +32,7 @@ Feature: Base UI Tests
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:

--- a/pagefind/features/ui/ui_hooks.feature
+++ b/pagefind/features/ui/ui_hooks.feature
@@ -1,14 +1,14 @@
 Feature: UI Hooks
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
 
     Scenario: Pagefind UI can provide a hook to process search terms
         Given I have a "public/index.html" file with the body:
             """
             <h1>Search</h1>
             <div id="search"></div>
-            <script src="/_pagefind/pagefind-ui.js"></script>
+            <script src="/pagefind/pagefind-ui.js"></script>
 
             <script>
                 window.pui = new PagefindUI({
@@ -19,7 +19,7 @@ Feature: UI Hooks
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
@@ -43,7 +43,7 @@ Feature: UI Hooks
             <h1>Search</h1>
             <img src="my.png" />
             <div id="search"></div>
-            <script src="/_pagefind/pagefind-ui.js"></script>
+            <script src="/pagefind/pagefind-ui.js"></script>
 
             <script>
                 window.pui = new PagefindUI({
@@ -57,7 +57,7 @@ Feature: UI Hooks
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:

--- a/pagefind/features/ui/ui_strings.feature
+++ b/pagefind/features/ui/ui_strings.feature
@@ -1,7 +1,7 @@
 Feature: UI Test Strings
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
 
     Scenario: Pagefind UI loads automatic translations
         Given I have a "public/index.html" file with the content:
@@ -12,7 +12,7 @@ Feature: UI Test Strings
                 <body>
                     <h1>Search</h1>
                     <div id="search"></div>
-                    <script src="/_pagefind/pagefind-ui.js"></script>
+                    <script src="/pagefind/pagefind-ui.js"></script>
 
                     <script>
                         window.pui = new PagefindUI({ element: "#search" });
@@ -22,7 +22,7 @@ Feature: UI Test Strings
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:
@@ -44,7 +44,7 @@ Feature: UI Test Strings
                 <body>
                     <h1>Search</h1>
                     <div id="search"></div>
-                    <script src="/_pagefind/pagefind-ui.js"></script>
+                    <script src="/pagefind/pagefind-ui.js"></script>
 
                     <script>
                         window.pui = new PagefindUI({
@@ -59,7 +59,7 @@ Feature: UI Test Strings
             """
         When I run my program
         Then I should see "Running Pagefind" in stdout
-        Then I should see the file "public/_pagefind/pagefind.js"
+        Then I should see the file "public/pagefind/pagefind.js"
         When I serve the "public" directory
         When I load "/"
         When I evaluate:

--- a/pagefind/features/weighting.feature
+++ b/pagefind/features/weighting.feature
@@ -1,7 +1,7 @@
 Feature: Word Weighting
     Background:
         Given I have the environment variables:
-            | PAGEFIND_SOURCE | public |
+            | PAGEFIND_SITE | public |
         Given I have a "public/index.html" file with the body:
             """
             <p>no results</p>
@@ -43,7 +43,7 @@ Feature: Word Weighting
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search(`antelope`);
 
@@ -84,7 +84,7 @@ Feature: Word Weighting
         When I evaluate:
             """
             async function() {
-                let pagefind = await import("/_pagefind/pagefind.js");
+                let pagefind = await import("/pagefind/pagefind.js");
 
                 let search = await pagefind.search(`antelope`);
 

--- a/pagefind/src/fossick/mod.rs
+++ b/pagefind/src/fossick/mod.rs
@@ -46,6 +46,7 @@ pub struct FossickedData {
     pub has_custom_body: bool,
     pub force_inclusion: bool,
     pub has_html_element: bool,
+    pub has_old_bundle_reference: bool,
     pub language: String,
 }
 
@@ -386,6 +387,7 @@ impl Fossicker {
             has_custom_body: data.has_custom_body,
             force_inclusion: data.force_inclusion,
             has_html_element: data.has_html_element,
+            has_old_bundle_reference: data.has_old_bundle_reference,
             language: data.language,
             fragment: PageFragment {
                 page_number: 0, // This page number is updated later once determined

--- a/pagefind/src/fossick/mod.rs
+++ b/pagefind/src/fossick/mod.rs
@@ -713,32 +713,34 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[test]
     fn building_url() {
-        std::env::set_var("PAGEFIND_SOURCE", "hello/world");
+        std::env::set_var("PAGEFIND_SITE", "hello/world");
         let config =
             PagefindInboundConfig::with_layers(&[Layer::Env(Some("PAGEFIND_".into()))]).unwrap();
         let opts = SearchOptions::load(config).unwrap();
 
-        let p: PathBuf = "hello/world/index.html".into();
+        let cwd = std::env::current_dir().unwrap();
+
+        let p: PathBuf = cwd.join::<PathBuf>("hello/world/index.html".into());
         assert_eq!(&build_url(&p, None, &opts), "/");
 
-        let p: PathBuf = "hello/world/about/index.html".into();
+        let p: PathBuf = cwd.join::<PathBuf>("hello/world/about/index.html".into());
         assert_eq!(&build_url(&p, None, &opts), "/about/");
 
-        let p: PathBuf = "hello/world/about.html".into();
+        let p: PathBuf = cwd.join::<PathBuf>("hello/world/about.html".into());
         assert_eq!(&build_url(&p, None, &opts), "/about.html");
 
-        let p: PathBuf = "hello/world/about/index.htm".into();
+        let p: PathBuf = cwd.join::<PathBuf>("hello/world/about/index.htm".into());
         assert_eq!(&build_url(&p, None, &opts), "/about/index.htm");
 
-        let p: PathBuf = "hello/world/index.html".into();
-        let root: PathBuf = "hello".into();
+        let p: PathBuf = cwd.join::<PathBuf>("hello/world/index.html".into());
+        let root: PathBuf = cwd.join::<PathBuf>("hello".into());
         assert_eq!(&build_url(&p, Some(&root), &opts), "/world/");
     }
 
     #[cfg(target_os = "windows")]
     #[test]
     fn building_windows_urls() {
-        std::env::set_var("PAGEFIND_SOURCE", "C:\\hello\\world");
+        std::env::set_var("PAGEFIND_SITE", "C:\\hello\\world");
         let config =
             PagefindInboundConfig::with_layers(&[Layer::Env(Some("PAGEFIND_".into()))]).unwrap();
         let opts = SearchOptions::load(config).unwrap();

--- a/pagefind/src/fossick/mod.rs
+++ b/pagefind/src/fossick/mod.rs
@@ -413,7 +413,7 @@ impl Fossicker {
 }
 
 fn build_url(page_url: &Path, relative_to: Option<&Path>, options: &SearchOptions) -> String {
-    let prefix = relative_to.unwrap_or(&options.source);
+    let prefix = relative_to.unwrap_or(&options.site_source);
     let trimmed = page_url.strip_prefix(prefix);
     let Ok(url) = trimmed else {
         options.logger.error(format!(

--- a/pagefind/src/index/index_filter.rs
+++ b/pagefind/src/index/index_filter.rs
@@ -1,8 +1,8 @@
 use minicbor::Encode;
 
-/// The filter index chunks in `_pagefind/filter/`
+/// The filter index chunks in `pagefind/filter/`
 
-/// A single filter index chunk: `_pagefind/filter/*.pf_filter`
+/// A single filter index chunk: `pagefind/filter/*.pf_filter`
 #[derive(Encode)]
 pub struct FilterIndex {
     #[n(0)]

--- a/pagefind/src/index/index_metadata.rs
+++ b/pagefind/src/index/index_metadata.rs
@@ -17,7 +17,7 @@ pub struct MetaIndex {
     pub sorts: Vec<MetaSort>,
 }
 
-/// Communicates the _pagefind/index/*.pf_index file we need to load
+/// Communicates the pagefind/index/*.pf_index file we need to load
 /// when searching for a word that sorts between `from` and `to`
 #[derive(Encode, PartialEq, Debug)]
 pub struct MetaChunk {

--- a/pagefind/src/index/index_words.rs
+++ b/pagefind/src/index/index_words.rs
@@ -1,8 +1,8 @@
 use minicbor::Encode;
 
-/// The word index chunks in `_pagefind/index/`
+/// The word index chunks in `pagefind/index/`
 
-/// A single word index chunk: `_pagefind/index/*.pf_index`
+/// A single word index chunk: `pagefind/index/*.pf_index`
 #[derive(Encode)]
 pub struct WordIndex {
     #[n(0)]

--- a/pagefind/src/main.rs
+++ b/pagefind/src/main.rs
@@ -63,7 +63,7 @@ async fn main() {
 
                     runner.log_start();
                     // TODO: Error handling
-                    _ = runner.fossick_many(options.source, options.glob).await;
+                    _ = runner.fossick_many(options.site_source, options.glob).await;
                     runner.build_indexes().await;
                     _ = &runner.write_files(None).await;
 
@@ -74,6 +74,18 @@ async fn main() {
                         duration.as_secs(),
                         duration.subsec_millis()
                     ));
+
+                    let warnings = options.config_warnings.get_strings();
+                    if !warnings.is_empty() {
+                        runner
+                            .options
+                            .logger
+                            .warn(&format!("{} configuration warning(s):", warnings.len()));
+
+                        for warning in options.config_warnings.get_strings() {
+                            runner.options.logger.warn(warning);
+                        }
+                    }
 
                     if config.serve {
                         pagefind::serve::serve_dir(PathBuf::from(config.source)).await;

--- a/pagefind/src/options.rs
+++ b/pagefind/src/options.rs
@@ -36,15 +36,14 @@ pub struct PagefindInboundConfig {
 
     #[clap(
         long,
-        short,
-        help = "Where to output the search files, relative to the processed site"
+        help = "Where to output the search bundle, relative to the processed site"
     )]
     #[clap(required = false)]
     pub output_subdir: Option<String>,
 
     #[clap(
         long,
-        help = "Where to output the search files, relative to the working directory of the command"
+        help = "Where to output the search bundle, relative to the working directory of the command"
     )]
     #[clap(required = false)]
     pub output_path: Option<String>,
@@ -116,7 +115,7 @@ pub struct PagefindInboundConfig {
     pub keep_index_url: bool,
 
     #[clap(long)]
-    #[clap(required = false)]
+    #[clap(required = false, hide = true)]
     #[serde(default = "defaults::default_false")]
     pub service: bool,
 }
@@ -218,7 +217,7 @@ impl SearchOptions {
                 .map(|o| working_directory.join(o))
                 .or(config.output_subdir.map(|o| site_source.join(o)))
                 .or(config.bundle_dir.map(|o| site_source.join(o)))
-                .unwrap_or_else(|| site_source.join(PathBuf::from("_pagefind")));
+                .unwrap_or_else(|| site_source.join(PathBuf::from("pagefind")));
 
             Ok(Self {
                 working_directory,

--- a/pagefind/src/options.rs
+++ b/pagefind/src/options.rs
@@ -30,7 +30,11 @@ pub struct PagefindInboundConfig {
     #[serde(default)] // This is actually required, but we validate that later
     pub site: String,
 
-    #[clap(long, short, help = "DEPRECATED: Use . . .")]
+    #[clap(
+        long,
+        short,
+        help = "DEPRECATED: Use `output_subdir` or `output_path` instead"
+    )]
     #[clap(required = false, hide = true)]
     pub bundle_dir: Option<String>,
 

--- a/pagefind/src/serve.rs
+++ b/pagefind/src/serve.rs
@@ -16,7 +16,11 @@ pub async fn serve_dir(dir: PathBuf) {
         }
     };
 
-    println!("Serving {dir:?} at http://localhost:{port}");
+    let rel_dir = dir
+        .strip_prefix(std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/")))
+        .unwrap_or(&dir);
+
+    println!("Serving {rel_dir:?} at http://localhost:{port}");
 
     match HttpServer::new(move || {
         App::new().service(fs::Files::new("/", &dir).index_file("index.html"))

--- a/pagefind/src/service/mod.rs
+++ b/pagefind/src/service/mod.rs
@@ -195,6 +195,7 @@ pub async fn run_service() {
                         has_custom_body: false,
                         force_inclusion: true,
                         has_html_element: true,
+                        has_old_bundle_reference: false,
                         language,
                     };
                     let file = Fossicker::new_with_data(url, data);

--- a/pagefind_ui/default/_dev_files/index.html
+++ b/pagefind_ui/default/_dev_files/index.html
@@ -5,14 +5,14 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- <link rel="stylesheet" href="/water.css"> -->
-    <link rel="stylesheet" href="/_pagefind/ui.css">
+    <link rel="stylesheet" href="/pagefind/ui.css">
     <title>Pagefind Local Dev Suite</title>
 </head>
 <body style="max-width: 1000px; padding: 80px; margin: 0 auto;">
     <h1>Hello World from the local dev suite</h1>
     <p>Searches for words ending in <kbd>y</kbd> will return no results</p>
     <div id="search"></div>
-    <script src="/_pagefind/ui.js"></script>
+    <script src="/pagefind/ui.js"></script>
     <script>
         new PagefindUI({ element: "#search" });
     </script>

--- a/pagefind_ui/default/build.js
+++ b/pagefind_ui/default/build.js
@@ -1,106 +1,113 @@
-import esbuild from 'esbuild';
-import path from 'path';
+import esbuild from "esbuild";
+import path from "path";
 import ImportGlobPlugin from "esbuild-plugin-import-glob";
 import sveltePlugin from "esbuild-svelte";
 import { createRequire } from "module";
-import { fileURLToPath } from 'url';
-import fs from 'fs';
+import { fileURLToPath } from "url";
+import fs from "fs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
-const { version } = require('./package.json');
+const { version } = require("./package.json");
 
 const sveltefixPlugin = {
-    name: 'fix_svelte_path',
-    setup(b) {
-        const require = createRequire(import.meta.url);
-        const svelteFileLocation = require.resolve('svelte');
-        const svelteFolderLocation = path.dirname(svelteFileLocation);
-        const nodeFolderLocation = path.dirname(svelteFolderLocation);
+  name: "fix_svelte_path",
+  setup(b) {
+    const require = createRequire(import.meta.url);
+    const svelteFileLocation = require.resolve("svelte");
+    const svelteFolderLocation = path.dirname(svelteFileLocation);
+    const nodeFolderLocation = path.dirname(svelteFolderLocation);
 
-        b.onResolve({ filter: /^svelte$|^svelte\// }, args => {
-            return { path: path.join(nodeFolderLocation, args.path, 'index.mjs') }
-        });
-    }
-}
+    b.onResolve({ filter: /^svelte$|^svelte\// }, (args) => {
+      return { path: path.join(nodeFolderLocation, args.path, "index.mjs") };
+    });
+  },
+};
 
 const serve = async () => {
-    const esbuildOptions = {
-        outdir: path.join(__dirname, "_dev_files/_pagefind"),
-        entryPoints: [path.join(__dirname, 'ui.js')],
-        plugins: [
-            ImportGlobPlugin.default(),
-            sveltePlugin({ compileOptions: { css: false } }),
-            sveltefixPlugin
-        ],
-        bundle: true,
-    }
+  const esbuildOptions = {
+    outdir: path.join(__dirname, "_dev_files/pagefind"),
+    entryPoints: [path.join(__dirname, "ui.js")],
+    plugins: [
+      ImportGlobPlugin.default(),
+      sveltePlugin({ compileOptions: { css: false } }),
+      sveltefixPlugin,
+    ],
+    bundle: true,
+  };
 
-    const context = await esbuild.context(esbuildOptions);
-    const server = await context.serve({ servedir: path.join(__dirname, "_dev_files") });
-    console.log(`Serving the dev suite on http://localhost:${server.port}`);
-}
+  const context = await esbuild.context(esbuildOptions);
+  const server = await context.serve({
+    servedir: path.join(__dirname, "_dev_files"),
+  });
+  console.log(`Serving the dev suite on http://localhost:${server.port}`);
+};
 
 const build = async () => {
-    const commonOpts = {
-        write: true,
-        plugins: [
-            ImportGlobPlugin.default(),
-            sveltePlugin({ compileOptions: { css: false } }),
-            sveltefixPlugin
-        ],
-        loader: {},
-        define: {},
-        bundle: true,
-    }
+  const commonOpts = {
+    write: true,
+    plugins: [
+      ImportGlobPlugin.default(),
+      sveltePlugin({ compileOptions: { css: false } }),
+      sveltefixPlugin,
+    ],
+    loader: {},
+    define: {},
+    bundle: true,
+  };
 
-    // Direct web vendor build
-    const esbuildVendorOptions = {
-        ...commonOpts,
-        minify: true,
-        entryPoints: [path.join(__dirname, 'ui.js')],
-        entryNames: `pagefind_[name].${version}`,
-        outdir: path.join(__dirname, `../../pagefind/vendor/`),
-    }
-    const compiledVendor = await esbuild.build(esbuildVendorOptions);
-    console.log(`Vendor Build: `, compiledVendor);
+  // Direct web vendor build
+  const esbuildVendorOptions = {
+    ...commonOpts,
+    minify: true,
+    entryPoints: [path.join(__dirname, "ui.js")],
+    entryNames: `pagefind_[name].${version}`,
+    outdir: path.join(__dirname, `../../pagefind/vendor/`),
+  };
+  const compiledVendor = await esbuild.build(esbuildVendorOptions);
+  console.log(`Vendor Build: `, compiledVendor);
 
-    // CJS "main" build
-    const esbuildCjsOptions = {
-        ...commonOpts,
-        entryPoints: [path.join(__dirname, 'ui-core.js')],
-        outdir: path.join(__dirname, `npm_dist/cjs/`),
-        outExtension: { '.js': '.cjs' },
-        platform: 'node',
-    }
-    const compiledCJS = await esbuild.build(esbuildCjsOptions);
-    stripCSSComment(path.join(__dirname, `npm_dist/cjs/ui-core.css`));
-    console.log(`CJS Build: `, compiledCJS);
+  // CJS "main" build
+  const esbuildCjsOptions = {
+    ...commonOpts,
+    entryPoints: [path.join(__dirname, "ui-core.js")],
+    outdir: path.join(__dirname, `npm_dist/cjs/`),
+    outExtension: { ".js": ".cjs" },
+    platform: "node",
+  };
+  const compiledCJS = await esbuild.build(esbuildCjsOptions);
+  stripCSSComment(path.join(__dirname, `npm_dist/cjs/ui-core.css`));
+  console.log(`CJS Build: `, compiledCJS);
 
-    // ESM Module Build
-    const esbuildModuleOptions = {
-        ...commonOpts,
-        entryPoints: [path.join(__dirname, 'ui-core.js')],
-        outdir: path.join(__dirname, `npm_dist/mjs/`),
-        outExtension: { '.js': '.mjs' },
-        platform: 'neutral',
-    }
-    const compiledMJS = await esbuild.build(esbuildModuleOptions);
-    stripCSSComment(path.join(__dirname, `npm_dist/mjs/ui-core.css`));
-    console.log(`Module Build: `, compiledMJS);
+  // ESM Module Build
+  const esbuildModuleOptions = {
+    ...commonOpts,
+    entryPoints: [path.join(__dirname, "ui-core.js")],
+    outdir: path.join(__dirname, `npm_dist/mjs/`),
+    outExtension: { ".js": ".mjs" },
+    platform: "neutral",
+  };
+  const compiledMJS = await esbuild.build(esbuildModuleOptions);
+  stripCSSComment(path.join(__dirname, `npm_dist/mjs/ui-core.css`));
+  console.log(`Module Build: `, compiledMJS);
 
-    try { fs.mkdirSync(path.join(__dirname, `css`)); } catch { }
-    fs.copyFileSync(path.join(__dirname, `npm_dist/mjs/ui-core.css`), path.join(__dirname, `css/ui.css`))
-}
+  try {
+    fs.mkdirSync(path.join(__dirname, `css`));
+  } catch {}
+  fs.copyFileSync(
+    path.join(__dirname, `npm_dist/mjs/ui-core.css`),
+    path.join(__dirname, `css/ui.css`)
+  );
+};
 
 const stripCSSComment = (file) => {
-    let contents = fs.readFileSync(file, { encoding: "utf-8" });
-    contents = contents.replace(/\/\* fakecss[^*]+\*\//g, '');
-    fs.writeFileSync(file, contents);
-}
+  let contents = fs.readFileSync(file, { encoding: "utf-8" });
+  contents = contents.replace(/\/\* fakecss[^*]+\*\//g, "");
+  fs.writeFileSync(file, contents);
+};
 
 if (process.env.PAGEFIND_DEV) {
-    serve();
+  serve();
 } else {
-    build();
+  build();
 }

--- a/pagefind_ui/default/svelte/ui.svelte
+++ b/pagefind_ui/default/svelte/ui.svelte
@@ -19,7 +19,7 @@
         };
     }
 
-    export let base_path = "/_pagefind/";
+    export let base_path = "/pagefind/";
     export let reset_styles = true;
     export let show_images = true;
     export let process_result = null;

--- a/pagefind_ui/default/ui-core.js
+++ b/pagefind_ui/default/ui-core.js
@@ -1,65 +1,76 @@
-import PagefindSvelte from './svelte/ui.svelte';
+import PagefindSvelte from "./svelte/ui.svelte";
 
 let scriptBundlePath;
 try {
-    scriptBundlePath = new URL(document.currentScript.src).pathname.match(/^(.*\/)(?:pagefind-)?ui.js.*$/)[1];
+  scriptBundlePath = new URL(document.currentScript.src).pathname.match(
+    /^(.*\/)(?:pagefind-)?ui.js.*$/
+  )[1];
 } catch (e) {
-    scriptBundlePath = "/_pagefind/";
-    console.warn(`Pagefind couldn't determine the base of the bundle from the javascript import path. Falling back to the default of ${scriptBundlePath}.`);
-    console.warn("You can configure this by passing a bundlePath option to PagefindUI");
-    console.warn(`[DEBUG: Loaded from ${document?.currentScript?.src ?? "unknown"}]`);
+  scriptBundlePath = "/pagefind/";
+  console.warn(
+    `Pagefind couldn't determine the base of the bundle from the javascript import path. Falling back to the default of ${scriptBundlePath}.`
+  );
+  console.warn(
+    "You can configure this by passing a bundlePath option to PagefindUI"
+  );
+  console.warn(
+    `[DEBUG: Loaded from ${document?.currentScript?.src ?? "unknown"}]`
+  );
 }
 
 export class PagefindUI {
-    constructor(opts) {
-        this._pfs = null;
+  constructor(opts) {
+    this._pfs = null;
 
-        let selector = opts.element ?? "[data-pagefind-ui]";
-        let bundlePath = opts.bundlePath ?? scriptBundlePath;
-        let resetStyles = opts.resetStyles ?? true;
-        let showImages = opts.showImages ?? true;
-        let processResult = opts.processResult ?? null;
-        let processTerm = opts.processTerm ?? null;
-        let showEmptyFilters = opts.showEmptyFilters ?? true;
-        let debounceTimeoutMs = opts.debounceTimeoutMs ?? 300;
-        let mergeIndex = opts.mergeIndex ?? [];
-        let translations = opts.translations ?? [];
+    let selector = opts.element ?? "[data-pagefind-ui]";
+    let bundlePath = opts.bundlePath ?? scriptBundlePath;
+    let resetStyles = opts.resetStyles ?? true;
+    let showImages = opts.showImages ?? true;
+    let processResult = opts.processResult ?? null;
+    let processTerm = opts.processTerm ?? null;
+    let showEmptyFilters = opts.showEmptyFilters ?? true;
+    let debounceTimeoutMs = opts.debounceTimeoutMs ?? 300;
+    let mergeIndex = opts.mergeIndex ?? [];
+    let translations = opts.translations ?? [];
 
-        // Remove the UI-specific config before passing it along to the Pagefind backend
-        delete opts["element"];
-        delete opts["bundlePath"];
-        delete opts["resetStyles"];
-        delete opts["showImages"];
-        delete opts["processResult"];
-        delete opts["processTerm"];
-        delete opts["showEmptyFilters"];
-        delete opts["debounceTimeoutMs"];
-        delete opts["mergeIndex"];
-        delete opts["translations"];
+    // Remove the UI-specific config before passing it along to the Pagefind backend
+    delete opts["element"];
+    delete opts["bundlePath"];
+    delete opts["resetStyles"];
+    delete opts["showImages"];
+    delete opts["processResult"];
+    delete opts["processTerm"];
+    delete opts["showEmptyFilters"];
+    delete opts["debounceTimeoutMs"];
+    delete opts["mergeIndex"];
+    delete opts["translations"];
 
-        const dom = selector instanceof HTMLElement ? selector : document.querySelector(selector);
-        if (dom) {
-            this._pfs = new PagefindSvelte({
-                target: dom,
-                props: {
-                    base_path: bundlePath,
-                    reset_styles: resetStyles,
-                    show_images: showImages,
-                    process_result: processResult,
-                    process_term: processTerm,
-                    show_empty_filters: showEmptyFilters,
-                    debounce_timeout_ms: debounceTimeoutMs,
-                    merge_index: mergeIndex,
-                    translations,
-                    pagefind_options: opts
-                }
-            })
-        } else {
-            console.error(`Pagefind UI couldn't find the selector ${selector}`);
-        }
+    const dom =
+      selector instanceof HTMLElement
+        ? selector
+        : document.querySelector(selector);
+    if (dom) {
+      this._pfs = new PagefindSvelte({
+        target: dom,
+        props: {
+          base_path: bundlePath,
+          reset_styles: resetStyles,
+          show_images: showImages,
+          process_result: processResult,
+          process_term: processTerm,
+          show_empty_filters: showEmptyFilters,
+          debounce_timeout_ms: debounceTimeoutMs,
+          merge_index: mergeIndex,
+          translations,
+          pagefind_options: opts,
+        },
+      });
+    } else {
+      console.error(`Pagefind UI couldn't find the selector ${selector}`);
     }
+  }
 
-    triggerSearch(term) {
-        this._pfs.$$set({ "trigger_search_term": term });
-    }
+  triggerSearch(term) {
+    this._pfs.$$set({ trigger_search_term: term });
+  }
 }

--- a/pagefind_ui/modular/README.md
+++ b/pagefind_ui/modular/README.md
@@ -18,8 +18,8 @@ The Pagefind Modular UI allows you to build a search UI out of Modules, all conn
 The Pagefind CLI outputs assets for the Modular UI that can be loaded directly:
 
 ```html
-<link href="/_pagefind/pagefind-modular-ui.css" rel="stylesheet">
-<script src="/_pagefind/pagefind-modular-ui.js"></script>
+<link href="/pagefind/pagefind-modular-ui.css" rel="stylesheet">
+<script src="/pagefind/pagefind-modular-ui.js"></script>
 
 <script>
     window.addEventListener('DOMContentLoaded', (event) => {
@@ -43,7 +43,7 @@ The Modular UI is also distributed as an NPM package:
 import { Instance, Input, ResultList } from "@pagefind/modular-ui";
 
 const instance = new Instance({
-    bundlePath: "/_pagefind/"
+    bundlePath: "/pagefind/"
 });
 instance.add(new Input({
     containerElement: "#searchbox"
@@ -63,19 +63,19 @@ import styles from "@pagefind/modular-ui/css/ui.css";
 
 ```js
 const instance = new Instance({
-    bundlePath: "/_pagefind/"
+    bundlePath: "/pagefind/"
 });
 ```
 
 An `Instance` serves as the central hub that all modules are connected to, and facilitates communication between each module and the Pagefind JS API.
 
-| Option | Description |
-|-|-|
-| `bundlePath` | See [UI > Bundle path](https://pagefind.app/docs/ui/#bundle-path) |
+| Option       | Description                                                                                                                         |
+|--------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `bundlePath` | See [UI > Bundle path](https://pagefind.app/docs/ui/#bundle-path)                                                                   |
 | `mergeIndex` | See [Searching additional sites from Pagefind UI](https://pagefind.app/docs/multisite/#searching-additional-sites-from-pagefind-ui) |
 
-| Method | Description |
-|-|-|
+| Method        | Description                          |
+|---------------|--------------------------------------|
 | `add(module)` | Connects a module to this `Instance` |
 
 ## Modules
@@ -94,11 +94,11 @@ instance.add(new Input({
 }));
 ```
 
-| Option | Description |
-|-|-|
-| `containerElement` | A selector to an element that a new search input should be placed within |
-| `inputElement` | A selector to an existing `<input />` element that should be used as the search input. _(NB: No Pagefind styling will be applied)_ |
-| `debounceTimeoutMs` | Number of ms (default: `300`) to wait before performing a search while a user is typing |
+| Option              | Description                                                                                                                        |
+|---------------------|------------------------------------------------------------------------------------------------------------------------------------|
+| `containerElement`  | A selector to an element that a new search input should be placed within                                                           |
+| `inputElement`      | A selector to an existing `<input />` element that should be used as the search input. _(NB: No Pagefind styling will be applied)_ |
+| `debounceTimeoutMs` | Number of ms (default: `300`) to wait before performing a search while a user is typing                                            |
 
 ### ResultList
 
@@ -108,11 +108,11 @@ instance.add(new ResultList({
 }));
 ```
 
-| Option | Description |
-|-|-|
-| `containerElement` | A selector to an element that the results should be placed within |
+| Option                | Description                                                               |
+|-----------------------|---------------------------------------------------------------------------|
+| `containerElement`    | A selector to an element that the results should be placed within         |
 | `placeholderTemplate` | A function that returns the template for a result that has not yet loaded |
-| `resultTemplate` | A function that returns the template for a search result |
+| `resultTemplate`      | A function that returns the template for a search result                  |
 
 ```js
 // Larger example:
@@ -141,13 +141,13 @@ instance.add(new FilterPills({
 }));
 ```
 
-| Option | Description |
-|-|-|
-| `containerElement` | A selector to an element that the filter pill row should be placed within |
-| `filter` | Which filter this row should represent. Filter name should exist in the search index |
-| `ordering` | An array containing the ideal order to display filter values in. Unmatched values will appear at the end |
-| `alwaysShow` | Whether to show the component when there are no results |
-| `selectMultiple` | Whether this component should toggle between single filter values, or allow multiple to be selected at once |
+| Option             | Description                                                                                                 |
+|--------------------|-------------------------------------------------------------------------------------------------------------|
+| `containerElement` | A selector to an element that the filter pill row should be placed within                                   |
+| `filter`           | Which filter this row should represent. Filter name should exist in the search index                        |
+| `ordering`         | An array containing the ideal order to display filter values in. Unmatched values will appear at the end    |
+| `alwaysShow`       | Whether to show the component when there are no results                                                     |
+| `selectMultiple`   | Whether this component should toggle between single filter values, or allow multiple to be selected at once |
 
 
 ### Summary
@@ -158,10 +158,10 @@ instance.add(new Summary({
 }));
 ```
 
-| Option | Description |
-|-|-|
+| Option             | Description                                                                   |
+|--------------------|-------------------------------------------------------------------------------|
 | `containerElement` | A selector to an element that the search summary text should be placed within |
-| `defaultMessage` | The text to show when there is no summary. Defaults to nothing |
+| `defaultMessage`   | The text to show when there is no summary. Defaults to nothing                |
 
 ### Custom Modules
 
@@ -205,7 +205,7 @@ Alternatively, you can react to events from the instance directly:
 
 ```js
 const instance = new Instance({
-    bundlePath: "/_pagefind/"
+    bundlePath: "/pagefind/"
 });
 instance.on("results", (results) => {
     // Search results are available

--- a/pagefind_ui/modular/_dev_files/index.html
+++ b/pagefind_ui/modular/_dev_files/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="/_pagefind/modular.css">
+    <link rel="stylesheet" href="/pagefind/modular.css">
     <title>Pagefind Local Dev Suite</title>
 </head>
 <body style="max-width: 1000px; padding: 80px; margin: 0 auto;">
@@ -21,7 +21,7 @@
     </pre>
     <h2>Later on, we have some results:</h2>
     <div id="resultlist"></div>
-    <script src="/_pagefind/modular.js"></script>
+    <script src="/pagefind/modular.js"></script>
     <script>
         const pagefind = new PagefindModularUI.Instance();
         pagefind.add(new PagefindModularUI.Input({

--- a/pagefind_ui/modular/build.js
+++ b/pagefind_ui/modular/build.js
@@ -1,84 +1,89 @@
-import esbuild from 'esbuild';
-import path from 'path';
+import esbuild from "esbuild";
+import path from "path";
 import ImportGlobPlugin from "esbuild-plugin-import-glob";
-import fs from 'fs';
+import fs from "fs";
 
 import { createRequire } from "module";
-import { fileURLToPath } from 'url';
-
+import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
-const { version } = require('./package.json');
-
+const { version } = require("./package.json");
 
 const serve = async () => {
-    const esbuildOptions = {
-        outdir: path.join(__dirname, "_dev_files/_pagefind"),
-        entryPoints: [path.join(__dirname, 'modular.js')],
-        plugins: [
-            ImportGlobPlugin.default(),
-        ],
-        bundle: true,
-    }
-    fs.rmSync(path.join(__dirname, `_dev_files/_pagefind/modular.css`));
-    fs.symlinkSync(path.join(__dirname, `css/ui.css`), path.join(__dirname, `_dev_files/_pagefind/modular.css`));
-    // fs.copyFileSync(path.join(__dirname, `css/ui.css`), path.join(__dirname, `_dev_files/_pagefind/modular.css`));
+  const esbuildOptions = {
+    outdir: path.join(__dirname, "_dev_files/pagefind"),
+    entryPoints: [path.join(__dirname, "modular.js")],
+    plugins: [ImportGlobPlugin.default()],
+    bundle: true,
+  };
+  fs.rmSync(path.join(__dirname, `_dev_files/pagefind/modular.css`));
+  fs.symlinkSync(
+    path.join(__dirname, `css/ui.css`),
+    path.join(__dirname, `_dev_files/pagefind/modular.css`)
+  );
+  // fs.copyFileSync(path.join(__dirname, `css/ui.css`), path.join(__dirname, `_dev_files/pagefind/modular.css`));
 
-    const context = await esbuild.context(esbuildOptions);
-    const server = await context.serve({ servedir: path.join(__dirname, "_dev_files") });
-    console.log(`Serving the dev suite on http://localhost:${server.port}`);
-}
+  const context = await esbuild.context(esbuildOptions);
+  const server = await context.serve({
+    servedir: path.join(__dirname, "_dev_files"),
+  });
+  console.log(`Serving the dev suite on http://localhost:${server.port}`);
+};
 
 const build = async () => {
-    const commonOpts = {
-        write: true,
-        plugins: [
-            ImportGlobPlugin.default(),
-        ],
-        loader: {},
-        define: {},
-        bundle: true,
-    }
+  const commonOpts = {
+    write: true,
+    plugins: [ImportGlobPlugin.default()],
+    loader: {},
+    define: {},
+    bundle: true,
+  };
 
-    // Direct web vendor build
-    const esbuildVendorOptions = {
-        ...commonOpts,
-        outdir: path.join(__dirname, `../../pagefind/vendor/`),
-        entryPoints: [path.join(__dirname, 'modular.js')],
-        entryNames: `pagefind_[name]_ui.${version}`,
-        minify: true,
-    }
-    const compiledVendor = await esbuild.build(esbuildVendorOptions);
-    console.log(compiledVendor);
+  // Direct web vendor build
+  const esbuildVendorOptions = {
+    ...commonOpts,
+    outdir: path.join(__dirname, `../../pagefind/vendor/`),
+    entryPoints: [path.join(__dirname, "modular.js")],
+    entryNames: `pagefind_[name]_ui.${version}`,
+    minify: true,
+  };
+  const compiledVendor = await esbuild.build(esbuildVendorOptions);
+  console.log(compiledVendor);
 
-    // CJS "main" build
-    const esbuildCjsOptions = {
-        ...commonOpts,
-        entryPoints: [path.join(__dirname, 'modular-core.js')],
-        outdir: path.join(__dirname, `npm_dist/cjs/`),
-        outExtension: { '.js': '.cjs' },
-        platform: 'node',
-    }
-    const compiledCJS = await esbuild.build(esbuildCjsOptions);
-    console.log(`CJS Build: `, compiledCJS);
+  // CJS "main" build
+  const esbuildCjsOptions = {
+    ...commonOpts,
+    entryPoints: [path.join(__dirname, "modular-core.js")],
+    outdir: path.join(__dirname, `npm_dist/cjs/`),
+    outExtension: { ".js": ".cjs" },
+    platform: "node",
+  };
+  const compiledCJS = await esbuild.build(esbuildCjsOptions);
+  console.log(`CJS Build: `, compiledCJS);
 
-    // ESM Module Build
-    const esbuildModuleOptions = {
-        ...commonOpts,
-        entryPoints: [path.join(__dirname, 'modular-core.js')],
-        outdir: path.join(__dirname, `npm_dist/mjs/`),
-        outExtension: { '.js': '.mjs' },
-        platform: 'neutral',
-    }
-    const compiledMJS = await esbuild.build(esbuildModuleOptions);
-    console.log(`Module Build: `, compiledMJS);
+  // ESM Module Build
+  const esbuildModuleOptions = {
+    ...commonOpts,
+    entryPoints: [path.join(__dirname, "modular-core.js")],
+    outdir: path.join(__dirname, `npm_dist/mjs/`),
+    outExtension: { ".js": ".mjs" },
+    platform: "neutral",
+  };
+  const compiledMJS = await esbuild.build(esbuildModuleOptions);
+  console.log(`Module Build: `, compiledMJS);
 
-    fs.copyFileSync(path.join(__dirname, `css/ui.css`), path.join(__dirname, `../../pagefind/vendor/pagefind_modular_ui.${version}.css`));
-}
+  fs.copyFileSync(
+    path.join(__dirname, `css/ui.css`),
+    path.join(
+      __dirname,
+      `../../pagefind/vendor/pagefind_modular_ui.${version}.css`
+    )
+  );
+};
 
 if (process.env.PAGEFIND_DEV) {
-    serve();
+  serve();
 } else {
-    build();
+  build();
 }

--- a/pagefind_ui/modular/modular-core.js
+++ b/pagefind_ui/modular/modular-core.js
@@ -3,166 +3,188 @@ export { ResultList } from "./components/resultList";
 export { Summary } from "./components/summary";
 export { FilterPills } from "./components/filterPills";
 
-const sleep = async (ms = 50) => await new Promise((resolve) => setTimeout(resolve, ms));
+const sleep = async (ms = 50) =>
+  await new Promise((resolve) => setTimeout(resolve, ms));
 
 let scriptBundlePath;
 try {
-    scriptBundlePath = new URL(document.currentScript.src).pathname.match(/^(.*\/)(?:pagefind-)?modular-ui.js.*$/)[1];
+  scriptBundlePath = new URL(document.currentScript.src).pathname.match(
+    /^(.*\/)(?:pagefind-)?modular-ui.js.*$/
+  )[1];
 } catch (e) {
-    scriptBundlePath = "/_pagefind/";
-    console.warn(`Pagefind couldn't determine the base of the bundle from the javascript import path. Falling back to the default of ${scriptBundlePath}.`);
-    // TODO(modular): Ensure bundlePath is available on Instance
-    console.warn("You can configure this by passing a bundlePath option to PagefindComposable Instance");
-    console.warn(`[DEBUG: Loaded from ${document?.currentScript?.src ?? "unknown"}]`);
+  scriptBundlePath = "/pagefind/";
+  console.warn(
+    `Pagefind couldn't determine the base of the bundle from the javascript import path. Falling back to the default of ${scriptBundlePath}.`
+  );
+  // TODO(modular): Ensure bundlePath is available on Instance
+  console.warn(
+    "You can configure this by passing a bundlePath option to PagefindComposable Instance"
+  );
+  console.warn(
+    `[DEBUG: Loaded from ${document?.currentScript?.src ?? "unknown"}]`
+  );
 }
 
 export class Instance {
-    constructor(opts = {}) {
-        this.__pagefind__ = null;
-        this.__initializing__ = null;
-        this.__searchID__ = 0;
-        this.__hooks__ = {
-            "search": [],
-            "filters": [],
-            "loading": [],
-            "results": []
-        };
+  constructor(opts = {}) {
+    this.__pagefind__ = null;
+    this.__initializing__ = null;
+    this.__searchID__ = 0;
+    this.__hooks__ = {
+      search: [],
+      filters: [],
+      loading: [],
+      results: [],
+    };
 
-        this.components = [];
+    this.components = [];
 
-        this.searchTerm = "";
-        this.searchFilters = {};
-        this.searchResult = {};
-        this.availableFilters = null;
-        this.totalFilters = null;
+    this.searchTerm = "";
+    this.searchFilters = {};
+    this.searchResult = {};
+    this.availableFilters = null;
+    this.totalFilters = null;
 
-        this.options = {
-            bundlePath: opts.bundlePath ?? scriptBundlePath,
-            //TODO: USE resetStyles: opts.resetStyles ?? true,
-            //TODO: USE processResult: opts.processResult ?? null,
-            //TODO: USE processTerm: opts.processTerm ?? null,
-            mergeIndex: opts.mergeIndex ?? [],
-            //TODO: USE translations: opts.translations ?? [],
+    this.options = {
+      bundlePath: opts.bundlePath ?? scriptBundlePath,
+      //TODO: USE resetStyles: opts.resetStyles ?? true,
+      //TODO: USE processResult: opts.processResult ?? null,
+      //TODO: USE processTerm: opts.processTerm ?? null,
+      mergeIndex: opts.mergeIndex ?? [],
+      //TODO: USE translations: opts.translations ?? [],
+    };
+
+    delete opts["bundlePath"];
+    delete opts["resetStyles"];
+    delete opts["processResult"];
+    delete opts["processTerm"];
+    delete opts["debounceTimeoutMs"];
+    delete opts["mergeIndex"];
+    delete opts["translations"];
+
+    // Remove the UI-specific config before passing it along to the Pagefind backend
+    this.pagefindOptions = opts;
+  }
+
+  add(component) {
+    component?.register?.(this);
+    this.components.push(component);
+  }
+
+  on(event, callback) {
+    if (!this.__hooks__[event]) {
+      const supportedEvents = Object.keys(this.__hooks__).join(", ");
+      console.error(
+        `[Pagefind Composable]: Unknown event type ${event}. Supported events: [${supportedEvents}]`
+      );
+      return;
+    }
+    if (typeof callback !== "function") {
+      console.error(
+        `[Pagefind Composable]: Expected callback to be a function, received ${typeof callback}`
+      );
+      return;
+    }
+    this.__hooks__[event].push(callback);
+  }
+
+  triggerLoad() {
+    this.__load__();
+    // this.components.forEach(component => component?.triggerLoad?.());
+  }
+
+  triggerSearch(term) {
+    this.searchTerm = term;
+    this.__dispatch__("search", term, this.searchFilters);
+    this.__search__(term, this.searchFilters);
+  }
+
+  triggerSearchWithFilters(term, filters) {
+    this.searchTerm = term;
+    this.searchFilters = filters;
+    this.__dispatch__("search", term, filters);
+    this.__search__(term, filters);
+  }
+
+  triggerFilters(filters) {
+    this.searchFilters = filters;
+    this.__dispatch__("search", this.searchTerm, filters);
+    this.__search__(this.searchTerm, filters);
+  }
+
+  triggerFilter(filter, values) {
+    this.searchFilters = this.searchFilters || {};
+    this.searchFilters[filter] = values;
+    this.__dispatch__("search", this.searchTerm, this.searchFilters);
+    this.__search__(this.searchTerm, this.searchFilters);
+  }
+
+  __dispatch__(e, ...args) {
+    this.__hooks__[e]?.forEach((hook) => hook?.(...args));
+  }
+
+  async __clear__() {
+    this.__dispatch__("results", { results: [], unfilteredTotalCount: 0 });
+    this.availableFilters = await this.__pagefind__.filters();
+    this.totalFilters = this.availableFilters;
+    this.__dispatch__("filters", {
+      available: this.availableFilters,
+      total: this.totalFilters,
+    });
+  }
+
+  async __search__(term, filters) {
+    this.__dispatch__("loading");
+    await this.__load__();
+    const thisSearch = ++this.__searchID__;
+
+    if (!term || !term.length) {
+      return this.__clear__();
+    }
+
+    const results = await this.__pagefind__.search(term, { filters });
+    if (results && this.__searchID__ === thisSearch) {
+      if (results.filters && Object.keys(results.filters)?.length) {
+        this.availableFilters = results.filters;
+        this.totalFilters = results.totalFilters;
+        this.__dispatch__("filters", {
+          available: this.availableFilters,
+          total: this.totalFilters,
+        });
+      }
+      this.searchResult = results;
+      this.__dispatch__("results", this.searchResult);
+    }
+  }
+
+  async __load__() {
+    if (this.__initializing__) {
+      while (!this.__pagefind__) {
+        await sleep(50);
+      }
+      return;
+    }
+    this.__initializing__ = true;
+    if (!this.__pagefind__) {
+      let imported_pagefind = await import(
+        `${this.options.bundlePath}pagefind.js`
+      );
+      await imported_pagefind.options(this.pagefindOptions || {});
+      for (const index of this.options.mergeIndex) {
+        if (!index.bundlePath) {
+          throw new Error("mergeIndex requires a bundlePath parameter");
         }
-
-        delete opts["bundlePath"];
-        delete opts["resetStyles"];
-        delete opts["processResult"];
-        delete opts["processTerm"];
-        delete opts["debounceTimeoutMs"];
-        delete opts["mergeIndex"];
-        delete opts["translations"];
-
-        // Remove the UI-specific config before passing it along to the Pagefind backend
-        this.pagefindOptions = opts;
+        const url = index.bundlePath;
+        delete index["bundlePath"];
+        await imported_pagefind.mergeIndex(url, index);
+      }
+      this.__pagefind__ = imported_pagefind;
     }
-
-    add(component) {
-        component?.register?.(this);
-        this.components.push(component);
-    }
-
-    on(event, callback) {
-        if (!this.__hooks__[event]) {
-            const supportedEvents = Object.keys(this.__hooks__).join(", ");
-            console.error(`[Pagefind Composable]: Unknown event type ${event}. Supported events: [${supportedEvents}]`);
-            return;
-        }
-        if (typeof callback !== "function") {
-            console.error(`[Pagefind Composable]: Expected callback to be a function, received ${typeof callback}`);
-            return;
-        }
-        this.__hooks__[event].push(callback);
-    }
-
-    triggerLoad() {
-        this.__load__();
-        // this.components.forEach(component => component?.triggerLoad?.());
-    }
-
-    triggerSearch(term) {
-        this.searchTerm = term;
-        this.__dispatch__("search", term, this.searchFilters);
-        this.__search__(term, this.searchFilters);
-    }
-
-    triggerSearchWithFilters(term, filters) {
-        this.searchTerm = term;
-        this.searchFilters = filters;
-        this.__dispatch__("search", term, filters);
-        this.__search__(term, filters);
-    }
-
-    triggerFilters(filters) {
-        this.searchFilters = filters;
-        this.__dispatch__("search", this.searchTerm, filters);
-        this.__search__(this.searchTerm, filters);
-    }
-
-    triggerFilter(filter, values) {
-        this.searchFilters = this.searchFilters || {};
-        this.searchFilters[filter] = values;
-        this.__dispatch__("search", this.searchTerm, this.searchFilters);
-        this.__search__(this.searchTerm, this.searchFilters);
-    }
-
-    __dispatch__(e, ...args) {
-        this.__hooks__[e]?.forEach(hook => hook?.(...args));
-    }
-
-    async __clear__() {
-        this.__dispatch__("results", {results: [], unfilteredTotalCount: 0});
-        this.availableFilters = await this.__pagefind__.filters();
-        this.totalFilters = this.availableFilters;
-        this.__dispatch__("filters", { available: this.availableFilters, total: this.totalFilters });
-    }
-
-    async __search__(term, filters) {
-        this.__dispatch__("loading");
-        await this.__load__();
-        const thisSearch = ++this.__searchID__;
-
-        if (!term || !term.length) {
-            return this.__clear__();
-        }
-
-        const results = await this.__pagefind__.search(term, { filters });
-        if (results && this.__searchID__ === thisSearch) {
-            if (results.filters && Object.keys(results.filters)?.length) {
-                this.availableFilters = results.filters;
-                this.totalFilters = results.totalFilters;
-                this.__dispatch__("filters", { available: this.availableFilters, total: this.totalFilters });
-            }
-            this.searchResult = results;
-            this.__dispatch__("results", this.searchResult);
-        }
-    }
-
-    async __load__() {
-        if (this.__initializing__) {
-            while (!this.__pagefind__) {
-                await sleep(50);
-            }
-            return;
-        };
-        this.__initializing__ = true;
-        if (!this.__pagefind__) {
-            let imported_pagefind = await import(`${this.options.bundlePath}pagefind.js`);
-            await imported_pagefind.options(this.pagefindOptions || {});
-            for (const index of this.options.mergeIndex) {
-                if (!index.bundlePath) {
-                    throw new Error(
-                        "mergeIndex requires a bundlePath parameter"
-                    );
-                }
-                const url = index.bundlePath;
-                delete index["bundlePath"];
-                await imported_pagefind.mergeIndex(url, index);
-            }
-            this.__pagefind__ = imported_pagefind;
-        }
-        this.availableFilters = await this.__pagefind__.filters();
-        this.totalFilters = this.availableFilters;
-        this.__dispatch__("filters", { available: this.availableFilters, total: this.totalFilters });
-    }
+    this.availableFilters = await this.__pagefind__.filters();
+    this.totalFilters = this.availableFilters;
+    this.__dispatch__("filters", {
+      available: this.availableFilters,
+      total: this.totalFilters,
+    });
+  }
 }

--- a/pagefind_web_js/lib/coupled_search.ts
+++ b/pagefind_web_js/lib/coupled_search.ts
@@ -78,7 +78,7 @@ class PagefindInstance {
     }
 
     defaultBasePath() {
-        let default_base = this.basePath.match(/^(.*\/)pagefind/)?.[1];
+        let default_base = this.basePath.match(/^(.*\/)_?pagefind/)?.[1];
         return default_base || "/";
     }
 

--- a/pagefind_web_js/lib/coupled_search.ts
+++ b/pagefind_web_js/lib/coupled_search.ts
@@ -39,7 +39,7 @@ class PagefindInstance {
         this.decoder = new TextDecoder('utf-8');
         this.wasm = null;
 
-        this.basePath = opts.basePath || "/_pagefind/";
+        this.basePath = opts.basePath || "/pagefind/";
         this.primary = opts.primary || false;
         if (this.primary) {
             this.initPrimary();
@@ -78,7 +78,7 @@ class PagefindInstance {
     }
 
     defaultBasePath() {
-        let default_base = this.basePath.match(/^(.*\/)_pagefind/)?.[1];
+        let default_base = this.basePath.match(/^(.*\/)pagefind/)?.[1];
         return default_base || "/";
     }
 

--- a/wrappers/node/README.md
+++ b/wrappers/node/README.md
@@ -47,7 +47,7 @@ await index.getFiles();
 
 // Write the index to disk
 await index.writeFiles({
-    bundlePath: "./public/_pagefind"
+    bundlePath: "./public/pagefind"
 });
 ```
 
@@ -173,7 +173,7 @@ Writes the index files to disk, as they would be written when running the standa
 
 ```js
 const { errors } = await index.writeFiles({
-    bundlePath: "./public/_pagefind"
+    bundlePath: "./public/pagefind"
 });
 ```
 

--- a/wrappers/node/types/index.d.ts
+++ b/wrappers/node/types/index.d.ts
@@ -160,7 +160,7 @@ export interface WriteOptions {
     /** 
      * The path of the pagefind bundle directory to write to disk.
      * If relative, is relative to the cwd.
-     * @example "./public/_pagefind"
+     * @example "./public/pagefind"
      */
     bundlePath: string
 }


### PR DESCRIPTION
This PR contains the main breaking(ish) changes for Pagefind 1.0

- The default location that Pagefind outputs files to is now `/pagefind/` instead of `/_pagefind/`
  - _Reasoning: Some hosting providers do not host directories that lead with an underscore by default:_
    - #188
  - **Backwards compat:** This is the main breaking change being introduced for 1.0.
    - In this PR, Pagefind will look at pages as it is indexing and see if it encounters any CSS or JS links with a `/_pagefind/...` URL. If one is found, then Pagefind will output all search files to **both** `/pagefind/` and `/_pagefind/`.
    - This approach will miss any setups where the page with search assets is excluded by a glob, or sites where the JS API is used directly from a script.
    - My hope is that the majority of sites are using the default UI, and sites using a more advanced setup are more likely to be setting a custom directory, or be pinning the version of Pagefind they run such that a conscious 1.0 migration is possible.
- The `--bundle-dir` option has been renamed to `--output-subdir`
  - _Reasoning: This option was repeatedly confusing:_
    - _#68_
    - _#138_
  - **Backwards compat:** `--bundle-dir` is still honoured (and warned on)
- A `--output-path` option that is **not** relative to the indexed site has been introduced
  - _Reasoning: Not a breaking change, but a new addition to help clarify the above option_
- The `--source` option has been renamed to `--site` for clarity
  - _Reasoning: By default Pagefind modifies this directory, which is unusual for a `source` directory. `site` is more neutral._
    - _Mentioned in #68_
  - **Backwards compat:** `--source` is still honoured (and warned on)
  - **Backwards compat:** `-s` now aliases to `site` instead of `source`