### PR TITLE
glob doc: Link to wax pattern docs for syntax

### DIFF
--- a/docs/content/docs/config-options.md
+++ b/docs/content/docs/config-options.md
@@ -71,6 +71,7 @@ Note that currently Pagefind only supports lists of options via configuration fi
 
 ### Glob
 Configures the glob used by Pagefind to discover HTML files. Defaults to `**/*.{html}`.
+See [Wax patterns documentation](https://github.com/olson-sean-k/wax#patterns) for more details.
 
 | CLI Flag        | ENV Variable    | Config Key |
 |-----------------|-----------------|------------|


### PR DESCRIPTION
Hi,

thanks for writing and maintaining pagefind, amazing technology :-)

I had to look through the code to figure out what was allowed as a glob.
Linking to upstream docs might make it easier for others who look for the same information.