### PR TITLE
Fix some compound word rankings

### DIFF
--- a/docs/content/docs/api-usage.md
+++ b/docs/content/docs/api-usage.md
@@ -99,14 +99,14 @@ Which will return an object with the following structure:
         "title": "The title from the first h1 element on the page",
         "url": "/url-of-the-page/",
         "locations": [ /* ... */ ],
-        "weightedLocations": [ /* ... */ ],
+        "weighted_locations": [ /* ... */ ],
         "excerpt": "A small snippet of the <mark>static</mark> content, with the search term(s) highlighted in &lt;mark&gt; elements",
     },
     {
         "title": "Inner text of some heading",
         "url": "/url-of-the-page/#id-of-the-h2",
         "locations": [ /* ... */ ],
-        "weightedLocations": [ /* ... */ ],
+        "weighted_locations": [ /* ... */ ],
         "excerpt": "A snippet of the <mark>static</mark> content, scoped between this anchor and the next one",
         "anchor": {
             "element": "h2",
@@ -117,7 +117,7 @@ Which will return an object with the following structure:
     }
   ],
   "locations": [ 4, 9, 18 ],
-  "weightedLocations": [
+  "weighted_locations": [
     {
         "weight": 1,
         "location": 4

--- a/docs/content/docs/api.md
+++ b/docs/content/docs/api.md
@@ -99,14 +99,14 @@ Which will return an object with the following structure:
         "title": "The title from the first h1 element on the page",
         "url": "/url-of-the-page/",
         "locations": [ /* ... */ ],
-        "weightedLocations": [ /* ... */ ],
+        "weighted_locations": [ /* ... */ ],
         "excerpt": "A small snippet of the <mark>static</mark> content, with the search term(s) highlighted in &lt;mark&gt; elements",
     },
     {
         "title": "Inner text of some heading",
         "url": "/url-of-the-page/#id-of-the-h2",
         "locations": [ /* ... */ ],
-        "weightedLocations": [ /* ... */ ],
+        "weighted_locations": [ /* ... */ ],
         "excerpt": "A snippet of the <mark>static</mark> content, scoped between this anchor and the next one",
         "anchor": {
             "element": "h2",
@@ -117,7 +117,7 @@ Which will return an object with the following structure:
     }
   ],
   "locations": [ 4, 9, 18 ],
-  "weightedLocations": [
+  "weighted_locations": [
     {
         "weight": 1,
         "location": 4

--- a/docs/content/docs/sub-results.md
+++ b/docs/content/docs/sub-results.md
@@ -84,7 +84,7 @@ Within the data for a page result, the `anchors`, `locations`, and `content` key
   "excerpt": "A small snippet of the <mark>static</mark> content, with the search term(s) highlighted in &lt;mark&gt; elements.",
 ~  "content": "The processed text content of this page ...",
 ~  "locations": [ 4, 18, 70 ],
-  "weightedLocations": [
+  "weighted_locations": [
     {
         "weight": 1,
         "location": 4
@@ -121,4 +121,4 @@ The `locations` key can be cross referenced with the list of `anchors` to determ
 
 The `content` key can be split on whitespace, and the `locations` will index into this content at the correct positions. This allows you to slice the content for each region of the page if you choose, and to generate a highlighted excerpt using that sliced content.
 
-Also available is the `weightedLocations` list, which can be used to further prioritise sections of the page if they contain higher value words.
+Also available is the `weighted_locations` list, which can be used to further prioritise sections of the page if they contain higher value words.

--- a/pagefind/src/fossick/mod.rs
+++ b/pagefind/src/fossick/mod.rs
@@ -260,7 +260,7 @@ impl Fossicker {
 
         let mut offset_word_index = 0;
         let mut max_word_index = 0;
-        let weight_multiplier = 25.0;
+        let weight_multiplier = 24.0;
         let weight_max = 10.0;
         debug_assert!(((weight_max * weight_multiplier) as u8) < std::u8::MAX);
 
@@ -570,14 +570,14 @@ mod tests {
                     "hello".to_string(),
                     vec![FossickedWord {
                         position: 0,
-                        weight: 1 * 25
+                        weight: 1 * 24
                     }]
                 ),
                 (
                     "world".to_string(),
                     vec![FossickedWord {
                         position: 1,
-                        weight: 1 * 25
+                        weight: 1 * 24
                     }]
                 )
             ])
@@ -610,28 +610,28 @@ mod tests {
                     "the".to_string(),
                     vec![FossickedWord {
                         position: 0,
-                        weight: 1 * 25
+                        weight: 1 * 24
                     }]
                 ),
                 (
                     "quick".to_string(),
                     vec![FossickedWord {
                         position: 1,
-                        weight: 2 * 25
+                        weight: 2 * 24
                     }]
                 ),
                 (
                     "brown".to_string(),
                     vec![FossickedWord {
                         position: 2,
-                        weight: 2 * 25
+                        weight: 2 * 24
                     }]
                 ),
                 (
                     "fox".to_string(),
                     vec![FossickedWord {
                         position: 3,
-                        weight: 1 * 25
+                        weight: 1 * 24
                     }]
                 ),
                 (
@@ -687,35 +687,35 @@ mod tests {
                 vec![
                     FossickedWord {
                         position: 0,
-                        weight: 7 * 25
+                        weight: 7 * 24
                     },
                     FossickedWord {
                         position: 1,
-                        weight: 6 * 25
+                        weight: 6 * 24
                     },
                     FossickedWord {
                         position: 2,
-                        weight: 5 * 25
+                        weight: 5 * 24
                     },
                     FossickedWord {
                         position: 3,
-                        weight: 4 * 25
+                        weight: 4 * 24
                     },
                     FossickedWord {
                         position: 4,
-                        weight: 3 * 25
+                        weight: 3 * 24
                     },
                     FossickedWord {
                         position: 5,
-                        weight: 2 * 25
+                        weight: 2 * 24
                     },
                     FossickedWord {
                         position: 6,
-                        weight: 1 * 25
+                        weight: 1 * 24
                     },
                     FossickedWord {
                         position: 7,
-                        weight: 0 * 25
+                        weight: 0 * 24
                     }
                 ]
             )])
@@ -746,14 +746,14 @@ mod tests {
                     "the".to_string(),
                     vec![FossickedWord {
                         position: 0,
-                        weight: 25
+                        weight: 24
                     }]
                 ),
                 (
                     "quick".to_string(),
                     vec![FossickedWord {
                         position: 1,
-                        weight: 250
+                        weight: 240
                     }]
                 ),
                 (
@@ -767,7 +767,7 @@ mod tests {
                     "fox".to_string(),
                     vec![FossickedWord {
                         position: 3,
-                        weight: 250
+                        weight: 240
                     }]
                 )
             ])

--- a/pagefind_ui/default/_dev_files/pagefind/_pagefind_stub.ts
+++ b/pagefind_ui/default/_dev_files/pagefind/_pagefind_stub.ts
@@ -43,7 +43,7 @@ const get_subs = (term, title, url, words) => {
     subs.push({
       title,
       url,
-      weightedLocations: [{ weight: 1, location: 1}, { weight: 2, location: 2}, { weight: 1, location: 3}],
+      weighted_locations: [{ weight: 1, location: 1}, { weight: 2, location: 2}, { weight: 1, location: 3}],
       locations: [1, 2, 3],
       excerpt: words.slice(0, 4).join(" "),
     });
@@ -63,7 +63,7 @@ const get_subs = (term, title, url, words) => {
         title: `${i}/${sub_count}: ${get_a_word()} ${get_a_word()} ${get_a_word()}`,
         url: `${url}#${get_a_word()}-${i}`,
         locations: locs,
-        weightedLocations: locs.map(location => { return { weight: 1, location}}),
+        weighted_locations: locs.map(location => { return { weight: 1, location}}),
         excerpt:
           words
             .slice(
@@ -104,7 +104,7 @@ const stub_results = (term): PagefindSearchResult[] => {
           excerpt,
           word_count: 30,
           locations: [7],
-          weightedLocations: [{ weight: 1, location: 7}],
+          weighted_locations: [{ weight: 1, location: 7}],
           filters: {
             color: [get_a_word()],
           },

--- a/pagefind_web_js/lib/coupled_search.ts
+++ b/pagefind_web_js/lib/coupled_search.ts
@@ -245,7 +245,7 @@ class PagefindInstance {
         return JSON.parse(new TextDecoder().decode(fragment));
     }
 
-    async loadFragment(hash: string, weightedLocations: PagefindWordLocation[] = []) {
+    async loadFragment(hash: string, weighted_locations: PagefindWordLocation[] = []) {
         if (!this.loaded_fragments[hash]) {
             this.loaded_fragments[hash] = this._loadFragment(hash);
         }
@@ -253,8 +253,8 @@ class PagefindInstance {
             raw_content: string,
             raw_url: string,
         };
-        fragment.weightedLocations = weightedLocations;
-        fragment.locations = weightedLocations.map(l => l.location);
+        fragment.weighted_locations = weighted_locations;
+        fragment.locations = weighted_locations.map(l => l.location);
 
         if (!fragment.raw_content) {
             fragment.raw_content = fragment.content.replace(/</g, '&lt;').replace(/>/g, '&gt;');
@@ -265,7 +265,7 @@ class PagefindInstance {
             fragment.url = this.fullUrl(fragment.raw_url);
         }
 
-        const excerpt_start = calculate_excerpt_region(weightedLocations, this.excerptLength);
+        const excerpt_start = calculate_excerpt_region(weighted_locations, this.excerptLength);
         fragment.excerpt = build_excerpt(fragment.raw_content, excerpt_start, this.excerptLength, fragment.locations);
 
         fragment.sub_results = calculate_sub_results(fragment, this.excerptLength);
@@ -419,16 +419,16 @@ class PagefindInstance {
         let resultsInterface = results.map(result => {
             let [hash, score, all_locations] = result.split('@');
             log(`Processing result: \n  hash:${hash}\n  score:${score}\n  locations:${all_locations}`);
-            let weightedLocations = all_locations.length ? all_locations.split(',').map(l => {
+            let weighted_locations = all_locations.length ? all_locations.split(',').map(l => {
                 let [weight, location ] = l.split('>').map(v => parseInt(v));
                 return { weight, location };
             }) : [];
-            let locations = weightedLocations.map(l => l.location);
+            let locations = weighted_locations.map(l => l.location);
             return {
                 id: hash,
                 score: parseFloat(score) * this.indexWeight,
                 words: locations,
-                data: async () => await this.loadFragment(hash, weightedLocations)
+                data: async () => await this.loadFragment(hash, weighted_locations)
             }
         });
 

--- a/pagefind_web_js/lib/coupled_search.ts
+++ b/pagefind_web_js/lib/coupled_search.ts
@@ -421,7 +421,7 @@ class PagefindInstance {
             log(`Processing result: \n  hash:${hash}\n  score:${score}\n  locations:${all_locations}`);
             let weighted_locations = all_locations.length ? all_locations.split(',').map(l => {
                 let [weight, location ] = l.split('>').map(v => parseInt(v));
-                return { weight, location };
+                return { weight: weight / 24.0, location };
             }) : [];
             let locations = weighted_locations.map(l => l.location);
             return {

--- a/pagefind_web_js/lib/excerpt.ts
+++ b/pagefind_web_js/lib/excerpt.ts
@@ -44,7 +44,7 @@ export const build_excerpt = (content: string, start: number, length: number, lo
         fragment_words = content.split(/[\r\n\s]+/g);
     }
     for (let word of locations) {
-        if (fragment_words[word].startsWith(`<mark>`)) {
+        if (fragment_words[word]?.startsWith(`<mark>`)) {
             // It's possible to have a word come up as multiple search hits
             continue;
         }

--- a/pagefind_web_js/lib/excerpt.ts
+++ b/pagefind_web_js/lib/excerpt.ts
@@ -44,6 +44,10 @@ export const build_excerpt = (content: string, start: number, length: number, lo
         fragment_words = content.split(/[\r\n\s]+/g);
     }
     for (let word of locations) {
+        if (fragment_words[word].startsWith(`<mark>`)) {
+            // It's possible to have a word come up as multiple search hits
+            continue;
+        }
         fragment_words[word] = `<mark>${fragment_words[word]}</mark>`;
     }
 

--- a/pagefind_web_js/lib/sub_results.ts
+++ b/pagefind_web_js/lib/sub_results.ts
@@ -15,14 +15,14 @@ export const calculate_sub_results = (
   let current_anchor: PagefindSubResult = {
     title: fragment.meta["title"],
     url: fragment.url,
-    weightedLocations: [],
+    weighted_locations: [],
     locations: [],
     excerpt: "",
   };
 
   const add_result = (end_range?: number) => {
     if (current_anchor.locations.length) {
-      const relative_weighted_locations = current_anchor.weightedLocations.map(
+      const relative_weighted_locations = current_anchor.weighted_locations.map(
         (l) => { return {weight: l.weight, location: l.location - current_anchor_position}}
       );
       const excerpt_start =
@@ -44,9 +44,9 @@ export const calculate_sub_results = (
     }
   };
 
-  for (let word of fragment.weightedLocations) {
+  for (let word of fragment.weighted_locations) {
     if (!anchors.length || word.location < anchors[0].location) {
-      current_anchor.weightedLocations.push(word);
+      current_anchor.weighted_locations.push(word);
       current_anchor.locations.push(word.location);
     } else {
       let next_anchor = anchors.shift()!;
@@ -86,7 +86,7 @@ export const calculate_sub_results = (
         title: next_anchor.text!,
         url: anchored_url,
         anchor: next_anchor,
-        weightedLocations: [word],
+        weighted_locations: [word],
         locations: [word.location],
         excerpt: "",
       };

--- a/pagefind_web_js/types/index.d.ts
+++ b/pagefind_web_js/types/index.d.ts
@@ -48,7 +48,7 @@ declare global {
         sub_results: PagefindSubResult[],
         word_count: number,
         locations: number[],
-        weightedLocations: PagefindWordLocation[],
+        weighted_locations: PagefindWordLocation[],
         filters: Record<string, string[]>
         meta: Record<string, string>,
         anchors: PagefindSearchAnchor[],
@@ -58,7 +58,7 @@ declare global {
         title: string,
         url: string,
         locations: number[],
-        weightedLocations: PagefindWordLocation[],
+        weighted_locations: PagefindWordLocation[],
         excerpt: string,
         anchor?: PagefindSearchAnchor,
     }


### PR DESCRIPTION
Further improves the deranking of compound words that are partially matched, and prevents wrapping excerpted compound words in nested `<mark>` tags.