### PR TITLE
Fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Ultimately, most contributions will require the ability to build the main Pagefi
 That binary compiles in some of our supporting facets, so you'll need to build those first.
 
 First, build the web JS bindings with:
-- `cd pagefind_web_js && npm i && npm run build`
+- `cd pagefind_web_js && npm i && npm run build-coupled`
 
 Next, build the UI packages with:
 - `cd pagefind_ui/default && npm i && npm run build`

--- a/docs/content/docs/config-options.md
+++ b/docs/content/docs/config-options.md
@@ -6,7 +6,7 @@ weight: 51
 ---
 
 The Pagefind CLI has the following options.  
-These can be set via any [configuration source](http://localhost:1313/docs/config-sources/).
+These can be set via any [configuration source](/docs/config-sources/).
 
 > These configuration options only apply when running the Pagefind indexing tool on your site.
 > For configuring Pagefind search in the browser, see [Pagefind Search Config](/docs/search-config/).  

--- a/docs/content/docs/node-api.md
+++ b/docs/content/docs/node-api.md
@@ -129,7 +129,7 @@ If successful, the `file` object is returned containing metadata about the compl
 Adds a direct record to the Pagefind index. Useful for adding non-HTML content to the search results.
 
 ```js
-const { errors, file } = await index.addHTMLFile({
+const { errors, file } = await index.addCustomRecord({
     url: "/contact/",
     content: "My raw content to be indexed for search. Will be lightly processed by Pagefind.",
     language: "en",


### PR DESCRIPTION
Few fixes for what I would consider to be typos.

 1. Building `pagefind_web_js/` requires `npm run build-coupled`
 2. Use relative link
 3. Fix example in documentation for `index.addCustomRecord`

Fixes #426.