### PR TITLE
Refactoring and fixing warnings

### DIFF
--- a/pagefind/src/fossick/mod.rs
+++ b/pagefind/src/fossick/mod.rs
@@ -588,7 +588,7 @@ mod tests {
         let mut f =
             test_fossick(["<html><body>", "<p>Hello World!</p>", "</body></html>"].concat()).await;
 
-        let (digest, words, anchors, word_count) = f.parse_digest();
+        let (digest, words, _, _) = f.parse_digest();
 
         assert_eq!(digest, "Hello World!".to_string());
         assert_eq!(
@@ -628,7 +628,7 @@ mod tests {
         )
         .await;
 
-        let (digest, words, anchors, word_count) = f.parse_digest();
+        let (digest, words, _, _) = f.parse_digest();
 
         assert_eq!(digest, "The Quick Brown. Fox Jumps Over. Ryan.".to_string());
         assert_eq!(
@@ -706,7 +706,7 @@ mod tests {
         )
         .await;
 
-        let (digest, words, anchors, word_count) = f.parse_digest();
+        let (_, words, _, _) = f.parse_digest();
 
         assert_eq!(
             words,
@@ -765,7 +765,7 @@ mod tests {
         )
         .await;
 
-        let (digest, words, anchors, word_count) = f.parse_digest();
+        let (_, words, _, _) = f.parse_digest();
 
         assert_eq!(
             words,

--- a/pagefind/src/index/mod.rs
+++ b/pagefind/src/index/mod.rs
@@ -66,7 +66,7 @@ pub async fn build_indexes(
     let mut fragment_hashes: HashMap<String, IntermediaryPageData> = HashMap::new();
     let mut fragments: Vec<(usize, (String, IntermediaryPageData))> = Vec::new();
 
-    for (page_number, mut page) in pages.iter_mut().enumerate() {
+    for (page_number, page) in pages.iter_mut().enumerate() {
         page.fragment.page_number = page_number;
     }
 

--- a/pagefind/src/lib.rs
+++ b/pagefind/src/lib.rs
@@ -4,7 +4,6 @@ pub use fossick::{FossickedData, Fossicker};
 use futures::future::join_all;
 use hashbrown::HashMap;
 use index::PagefindIndexes;
-use logging::Logger;
 pub use options::{PagefindInboundConfig, SearchOptions};
 use output::SyntheticFile;
 use wax::{Glob, WalkEntry};

--- a/pagefind/src/lib.rs
+++ b/pagefind/src/lib.rs
@@ -293,7 +293,7 @@ impl SearchState {
         )
         .await;
 
-        output::write_common_to_disk(&self.options, index_entries, &outdir).await;
+        output::write_common_to_disk(index_entries, &outdir).await;
 
         outdir
     }
@@ -317,7 +317,7 @@ impl SearchState {
             .collect();
 
         files.extend(
-            output::write_common_to_memory(&self.options, index_entries, outdir)
+            output::write_common_to_memory(index_entries, outdir)
                 .await
                 .into_iter(),
         );

--- a/pagefind/src/options.rs
+++ b/pagefind/src/options.rs
@@ -216,12 +216,15 @@ impl SearchOptions {
                 using_deprecated_bundle_dir: config.bundle_dir.is_some(),
             };
 
-            let bundle_output = config
-                .output_path
-                .map(|o| working_directory.join(o))
-                .or(config.output_subdir.map(|o| site_source.join(o)))
-                .or(config.bundle_dir.map(|o| site_source.join(o)))
-                .unwrap_or_else(|| site_source.join(PathBuf::from("pagefind")));
+            let bundle_output = if let Some(subdir) = config.output_path {
+                working_directory.join(subdir)
+            } else {
+                let subdir = config
+                    .output_subdir
+                    .or(config.bundle_dir)
+                    .unwrap_or_else(|| defaults::default_bundle_dir());
+                site_source.join(subdir)
+            };
 
             Ok(Self {
                 working_directory,

--- a/pagefind/src/options.rs
+++ b/pagefind/src/options.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 use clap::Parser;
 use rust_patch::Patch;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, env, path::PathBuf};
+use std::{env, path::PathBuf};
 use twelf::config;
 
 use crate::logging::{LogLevel, Logger};

--- a/pagefind/src/output/mod.rs
+++ b/pagefind/src/output/mod.rs
@@ -71,25 +71,22 @@ pub struct LanguageMeta {
 }
 
 pub async fn write_common_to_disk(
-    options: &SearchOptions,
     language_indexes: Vec<LanguageMeta>,
     outdir: &PathBuf,
 ) {
-    write_common(options, language_indexes, outdir, false).await;
+    write_common(language_indexes, outdir, false).await;
 }
 
 pub async fn write_common_to_memory(
-    options: &SearchOptions,
     language_indexes: Vec<LanguageMeta>,
     outdir: &PathBuf,
 ) -> Vec<SyntheticFile> {
-    write_common(options, language_indexes, outdir, true)
+    write_common(language_indexes, outdir, true)
         .await
         .unwrap()
 }
 
 async fn write_common(
-    options: &SearchOptions,
     language_indexes: Vec<LanguageMeta>,
     outdir: &PathBuf,
     synthetic: bool,


### PR DESCRIPTION
Nothing big. Just fixing some warnings reported by `cargo` and refactoring a small code snippet to use the previously unused `defaults::default_bundle_dir`. I also removed some `SearchOptions` parameters from a few functions as they were unused.  