### PR TITLE
Fix `debouncedSearch()` when passing an options object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Unreleased
 
+* Fixes a bug where `debouncedSearch` returns `null` if any options object is passed to it.
+
 ## v1.0.3 (September 16, 2023)
 
 Hopefully the last hotfix for now — bugfixes only important for sites indexing Japanese or Chinese pages.

--- a/pagefind/features/debounce.feature
+++ b/pagefind/features/debounce.feature
@@ -40,3 +40,36 @@ Feature: Debounced Searches
         Then There should be no logs
         Then The selector "[data-types]" should contain "null, null, null, null, 1"
         Then The selector "[data-last]" should contain "/cat/"
+
+    Scenario: Debounce with options
+        Given I have a "public/cat/index.html" file with the body:
+            """
+            <h1>world</h1>
+            """
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        Then I should see the file "public/pagefind/pagefind.js"
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/pagefind/pagefind.js");
+
+                let results = await Promise.all([
+                    pagefind.debouncedSearch("a", { filters: {} }),
+                    pagefind.debouncedSearch("w", { filters: {} }),
+                    pagefind.debouncedSearch("wo", { filters: {} }),
+                    pagefind.debouncedSearch("wor", { filters: {} }),
+                    pagefind.debouncedSearch("worl", { filters: {} })
+                ]);
+
+                document.querySelector('[data-types]').innerText = results.map(r => (r === null ? "null" : r.results.length)).join(', ');
+
+                let pages = await Promise.all(results[4].results.map(r => r.data()));
+                document.querySelector('[data-last]').innerText = pages.map(p => p.url).sort().join(", ");
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-types]" should contain "null, null, null, null, 1"
+        Then The selector "[data-last]" should contain "/cat/"

--- a/pagefind_web_js/lib/coupled_search.ts
+++ b/pagefind_web_js/lib/coupled_search.ts
@@ -346,8 +346,10 @@ class PagefindInstance {
     }
 
     async preload(term: string, options: PagefindSearchOptions = {}) {
-        options.preload = true;
-        await this.search(term, options);
+        await this.search(term, {
+            ...options,
+            preload: true
+        });
     }
 
     async search(term: string, options: PagefindSearchOptions = {}): Promise<PagefindSearchResults | null> {


### PR DESCRIPTION
See issue #441 