### PR TITLE
Fix duration representation

### DIFF
--- a/pagefind/src/main.rs
+++ b/pagefind/src/main.rs
@@ -92,7 +92,7 @@ async fn main() {
                     let duration = start.elapsed();
 
                     logger.status(&format!(
-                        "Finished in {}.{} seconds",
+                        "Finished in {}.{:03} seconds",
                         duration.as_secs(),
                         duration.subsec_millis()
                     ));


### PR DESCRIPTION
Currently if pagefind takes e.g. 1 ms it would be incorrectly displayed as "0.1 seconds" instead of "0.001 seconds". This patch fixes the behaviour.