### PR TITLE
Avoid processing fully qualified URLs when returning results from the web js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Unreleased
 
 * Fixes a bug where `debouncedSearch` returns `null` if any options object is passed to it.
+* Fixes a bug where a fully-qualified URL set via the NodeJS indexing API would be broken when returned as a search result.
 
 ## v1.0.3 (September 16, 2023)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1699,6 +1699,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicbor"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d15f4203d71fdf90903c2696e55426ac97a363c67b218488a73b534ce7aca10"
+
+[[package]]
 name = "minicbor-derive"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1826,7 +1832,7 @@ dependencies = [
  "lazy_static",
  "lexical-core",
  "lol_html",
- "minicbor",
+ "minicbor 0.19.1",
  "minifier",
  "pagefind_stem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "path-slash",
@@ -1863,7 +1869,7 @@ name = "pagefind_web"
 version = "0.0.0"
 dependencies = [
  "bit-set",
- "minicbor",
+ "minicbor 0.20.0",
  "pagefind_microjson",
  "pagefind_stem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen",

--- a/pagefind/features/highlighting/highlighting_base.feature
+++ b/pagefind/features/highlighting/highlighting_base.feature
@@ -56,11 +56,11 @@ Feature: Highlighting Tests
             <script type="module">
                 await import('/pagefind/pagefind-highlight.js');
                 new PagefindHighlight({
-                pagefindQueryParamName: 'custom-name', 
-                markOptions: { 
-                        className: 'custom-class', 
+                pagefindQueryParamName: 'custom-name',
+                markOptions: {
+                        className: 'custom-class',
                         exclude: [
-                            "[data-pagefind-ignore]", 
+                            "[data-pagefind-ignore]",
                             "[data-pagefind-ignore] *",
                             ".ignore"
                             ]
@@ -74,11 +74,19 @@ Feature: Highlighting Tests
 
     Scenario: Highlight script is loaded
         When I load "/words/"
+        When I evaluate:
+            """
+            async function() { await new Promise(r => setTimeout(r, 200)); }
+            """
         Then I should see the file "public/pagefind/pagefind-highlight.js"
         Then There should be no logs
 
     Scenario: Highlight script marks correctly
         When I load "/words/?pagefind-highlight=this"
+        When I evaluate:
+            """
+            async function() { await new Promise(r => setTimeout(r, 200)); }
+            """
         Then There should be no logs
         Then The selector "#has-highlight mark" should contain "this"
         Then The selector "#has-highlight mark.pagefind-highlight" should contain "this"
@@ -101,6 +109,10 @@ Feature: Highlighting Tests
 
     Scenario: Highlight script stays within pagefind-body
         When I load "/single-body/?pagefind-highlight=this"
+        When I evaluate:
+            """
+            async function() { await new Promise(r => setTimeout(r, 200)); }
+            """
         Then There should be no logs
         Then The selector "#has-highlight mark" should contain "This"
         Then The selector "p[data-pagefind-ignore]" should contain "This should not be highlighted"
@@ -113,10 +125,14 @@ Feature: Highlighting Tests
 
     Scenario: Highlight script options work
         When I load "/options/?custom-name=this"
+        When I evaluate:
+            """
+            async function() { await new Promise(r => setTimeout(r, 200)); }
+            """
         Then There should be no logs
         Then The selector "#has-highlight mark" should contain "This"
         Then The selector "#has-highlight mark.custom-class" should contain "This"
         Then The selector "p[data-pagefind-ignore]" should contain "This should not be highlighted"
         Then The selector "p.ignore" should contain "This should not be highlighted"
         Then The selector "#no-highlight" should contain "This should not be highlighted"
-        
+

--- a/pagefind/features/urls.feature
+++ b/pagefind/features/urls.feature
@@ -1,0 +1,58 @@
+Feature: URL tests
+    Background:
+        Given I have the environment variables:
+            | PAGEFIND_SITE | public |
+        Given I have a "public/index.html" file with the body:
+            """
+            <p data-url>Nothing</p>
+            """
+        Given I have a "public/package.json" file with the content:
+            """
+            {
+                "name": "test",
+                "type": "module",
+                "version": "1.0.0",
+                "main": "index.js",
+                "dependencies": {
+                    "pagefind": "file:{{humane_cwd}}/../wrappers/node"
+                }
+            }
+            """
+
+    @platform-unix
+    Scenario: Tag pages as external URLs
+        Given I have a "public/index.js" file with the content:
+            """
+             import * as pagefind from "pagefind";
+
+             const run = async () => {
+                 const { index } = await pagefind.createIndex();
+                 await index.addCustomRecord({
+                     url: "https://example.com/external-url/",
+                     content: "Hello World!",
+                     language: "en"
+                 });
+                 await index.writeFiles();
+                 console.log(`Successfully wrote files`);
+             }
+
+             run();
+            """
+        When I run "cd public && npm i && PAGEFIND_BINARY_PATH={{humane_cwd}}/$TEST_BINARY node index.js"
+        Then I should see "Successfully wrote files" in stdout
+        Then I should see the file "public/pagefind/pagefind.js"
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+             async function() {
+                 let pagefind = await import("/pagefind/pagefind.js");
+
+                 let search = await pagefind.search("world");
+
+                 let data = await search.results[0].data();
+                 document.querySelector('[data-url]').innerText = data.url;
+             }
+            """
+        Then There should be no logs
+        Then The selector "[data-url]" should contain "https://example.com/external-url/"

--- a/pagefind_web_js/lib/coupled_search.ts
+++ b/pagefind_web_js/lib/coupled_search.ts
@@ -274,6 +274,10 @@ class PagefindInstance {
     }
 
     fullUrl(raw: string) {
+        // Avoid processing absolute URLs
+        if (/^(https?:)?\/\//.test(raw)) {
+            return raw;
+        }
         return `${this.baseUrl}/${raw}`.replace(/\/+/g, "/").replace(/^(https?:\/)/, "$1/");
     }
 


### PR DESCRIPTION
Fixes #468