### PR TITLE
Final polish for the highlighting feature

### DIFF
--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -53,19 +53,6 @@ We can see that a bunch of content was indexed, and Pagefind will be running a p
 
 Loading this in your browser, you should see a search input on your page. Try searching for some content and you will see results appear from your site.
 
-## Highlighting
-
-To highlight the search terms on results page, add the following snippet on every page that has been indexed
-
-```html
-<script src="/pagefind/pagefind-highlight.js"></script>
-<script>
-    new PagefindHighlight();
-<script>
-```
-
-See [Highlighting search terms](/docs/highlighting/) for more information.
-
 The last required step is to run Pagefind after building your site on your CMS or hosting platform. If you're a CloudCannon user, add a [`.cloudcannon/postbuild`](https://cloudcannon.com/documentation/articles/extending-your-build-process-with-hooks/) file containing the npx command above (minus the `--serve` flag). For other platforms, set up an equivalent command to run after your site build — the end goal is that Pagefind will run after every build of your site before it is deployed.
 
 For many use cases, you can stop here and mark it as complete. Or, you can dive deeper into Pagefind and configure it to your liking — check out [Configuring the index](/docs/indexing/) for some next steps.

--- a/docs/content/docs/highlight-config.md
+++ b/docs/content/docs/highlight-config.md
@@ -16,13 +16,13 @@ new PagefindHighlight({ markContext: "[data-pagefind-body]" })
 
 The area in which to highlight text. Defaults to `[data-pagefind-body]` if any `[data-pagefind-body]` elements can be found, otherwise `document.body`. This can be a CSS selector string, a DOM element, an array of DOM elements, or a NodeList.
 
-### pagefindQueryParamName
+### highlightParam
 
 ```js
-new PagefindHighlight({ pagefindQueryParamName: "pagefind-highlight" })
+new PagefindHighlight({ highlightParam: "highlight" })
 ```
 
-The name of the query parameter that Pagefind uses to determine which terms to highlight. Defaults to `pagefind-highlight`. If the name is changed here, it *must* be changed in the [`PagefindUI` object](/docs/ui/#highlight-query-param-name) as well.
+The name of the query parameter that Pagefind uses to determine which terms to highlight. This must match the [Pagefind highlightParam config](/docs/search-config/#highlight-query-parameter).
 
 ### markOptions
 

--- a/docs/content/docs/highlighting.md
+++ b/docs/content/docs/highlighting.md
@@ -5,13 +5,47 @@ nav_section: Searching
 weight: 10
 ---
 
-Pagefind allows you to highlight search terms on the result page. To enable this feature, import `/pagefind/pagefind-highlight.js` on the result page and create a new `PagefindHighlight` object.
+Pagefind includes the ability to highlight search terms on the result page.
+
+To enable this feature, first configure Pagefind to insert a query parameter on search results.
+
+## Configuring highlighting via the Default UI
+
+{{< diffcode >}}
+```javascript
+new PagefindUI({
+    element: "#search",
++    highlightParam: "highlight"
+});
+```
+{{< /diffcode >}}
+
+## Configuring highlighting via the JavaScript API
+
+{{< diffcode >}}
+```javascript
+const pagefind = await import("/pagefind/pagefind.js");
+await pagefind.options({
++    highlightParam: "highlight"
+});
+const search = await pagefind.search("static");
+```
+{{< /diffcode >}}
+
+## Enabling highlights on result pages
+
+Once Pagefind is configured to insert query parameters, pages on your site will need to opt-in to highlighting.
+This is something you can implement for your own site by looking at the query parameter, but Pagefind provides a highlighting script for convenience.
+
+To opt-in, import `/pagefind/pagefind-highlight.js` on all pages of your site and create a new `PagefindHighlight` object.
 
 ```html
-<script src="/pagefind/pagefind-highlight.js"></script>
-<script>
-    new PagefindHighlight();
-<script>
+<script type="module">
+    await import('/pagefind/pagefind-highlight.js');
+    new PagefindHighlight({ highlightParam: "highlight" });
+</script>
 ```
 
-To see the options available to PagefindHighlight, see [Highlight Config](/docs/highlight-config).
+Ensure that the `highlightParam` configured here matches the `highlightParam` given to Pagefind when searching.
+
+To see all options available to PagefindHighlight, see [Highlight Config](/docs/highlight-config).

--- a/docs/content/docs/search-config.md
+++ b/docs/content/docs/search-config.md
@@ -67,6 +67,18 @@ Overrides the bundle directory. In most cases this should be automatically detec
 
 Set the maximum length for generated excerpts. Defaults to `30`.
 
+### Highlight query parameter
+
+```json
+{
+    "highlightParam": "highlight"
+}
+```
+
+If set, Pagefind will add the search term as a query parameter under the same name. 
+
+If using the [Pagefind highlight script](/docs/highlighting/), make sure this is configured to match.
+
 ### Index weight
 
 See [multisite search > weighting](/docs/multisite/#changing-the-weighting-of-individual-indexes)

--- a/docs/content/docs/ui.md
+++ b/docs/content/docs/ui.md
@@ -152,19 +152,6 @@ new PagefindUI({
 
 The number of milliseconds to wait after a user stops typing before performing a search. Defaults to `300`. If you wish to disable this, set to `0`.
 
-### Highlight query param name
-
-{{< diffcode >}}
-```javascript
-new PagefindUI({
-    element: "#search",
-+    highlightQueryParamName: 'highlight'
-});
-```
-{{< /diffcode >}}
-
-If the parameter is changed here, it *must* be changed in the [`PagefindHighlight` object](/docs/highlight-config/#pagefindQueryParamName) as well.
-
 ### Translations
 
 {{< diffcode >}}

--- a/pagefind/features/highlighting/highlighting_results.feature
+++ b/pagefind/features/highlighting/highlighting_results.feature
@@ -1,4 +1,4 @@
-Feature: Highlighting Tests
+Feature: Highlighting Result Tests
 
     Background:
         Given I have the environment variables:
@@ -56,7 +56,7 @@ Feature: Highlighting Tests
             <script type="module">
                 await import('/pagefind/pagefind-highlight.js');
                 new PagefindHighlight({
-                pagefindQueryParamName: 'custom-name',
+                highlightParam: 'custom-name',
                 markOptions: {
                         className: 'custom-class',
                         exclude: [

--- a/pagefind/features/highlighting/highlighting_search.feature
+++ b/pagefind/features/highlighting/highlighting_search.feature
@@ -1,0 +1,81 @@
+Feature: Highlighting Search Tests
+
+    Background:
+        Given I have the environment variables:
+            | PAGEFIND_SITE | public |
+        Given I have a "public/index.html" file with the body:
+            """
+            <p data-url>Nothing</p>
+            """
+        Given I have a "public/a/index.html" file with the body:
+            """
+            <p>Hello World</p>
+            """
+        Given I have a "public/b/index.html" file with the body:
+            """
+            <h2 id="second">Second</h2>
+            <p>Second Page</p>
+            """
+
+    Scenario: Query parameters can be inserted through the JS API
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        Then I should see the file "public/pagefind/pagefind.js"
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/pagefind/pagefind.js");
+                await pagefind.options({ highlightParam: "hi" });
+
+                let search = await pagefind.search("world");
+
+                let data = await search.results[0].data();
+                document.querySelector('[data-url]').innerText = data.url;
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-url]" should contain "/a/?hi=world"
+
+    Scenario: Multiple query parameters are inserted through the JS API
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        Then I should see the file "public/pagefind/pagefind.js"
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/pagefind/pagefind.js");
+                await pagefind.options({ highlightParam: "hi" });
+
+                let search = await pagefind.search("hello world");
+
+                let data = await search.results[0].data();
+                document.querySelector('[data-url]').innerText = data.url;
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-url]" should contain "/a/?hi=hello&amp;hi=world"
+
+    Scenario: Query parameters don't conflict with subresult anchors
+        When I run my program
+        Then I should see "Running Pagefind" in stdout
+        Then I should see the file "public/pagefind/pagefind.js"
+        When I serve the "public" directory
+        When I load "/"
+        When I evaluate:
+            """
+            async function() {
+                let pagefind = await import("/pagefind/pagefind.js");
+                await pagefind.options({ highlightParam: "hi" });
+
+                let search = await pagefind.search("second");
+
+                let data = await search.results[0].data();
+                document.querySelector('[data-url]').innerText = data.sub_results[0].url;
+            }
+            """
+        Then There should be no logs
+        Then The selector "[data-url]" should contain "/b/?hi=second#second"

--- a/pagefind/features/ui/ui_highlight.feature
+++ b/pagefind/features/ui/ui_highlight.feature
@@ -9,14 +9,14 @@ Feature: Base UI Tests
 
     Scenario: Pagefind UI adds highlight query params
         Given I have a "public/index.html" file with the body:
-                """
+            """
                 <div id="search"></div>
                 <script src="/pagefind/pagefind-ui.js"></script>
 
                 <script>
-                    window.pui = new PagefindUI({ element: "#search" });
+                    window.pui = new PagefindUI({ element: "#search", highlightParam: "pagefind-highlight" });
                 </script>
-                """
+            """
         Given I have a "public/cat/index.html" file with the body:
             """
             <h1>hello world</h1>
@@ -53,18 +53,18 @@ Feature: Base UI Tests
             }
             """
         Then There should be no logs
-        Then The selector ".pagefind-ui__result-link[href$='?pagefind-highlight=hello&pagefind-highlight=world%21']" should contain "hello world"
+        Then The selector ".pagefind-ui__result-link[href$='?pagefind-highlight=hello&pagefind-highlight=world']" should contain "hello world"
 
-    Scenario: Pagefind UI does not add highlight query params
+    Scenario: Pagefind UI does not add highlight query params by default
         Given I have a "public/index.html" file with the body:
-                """
+            """
                 <div id="search"></div>
                 <script src="/pagefind/pagefind-ui.js"></script>
 
                 <script>
-                    window.pui = new PagefindUI({ element: "#search", highlightQueryParamName: null });
+                    window.pui = new PagefindUI({ element: "#search" });
                 </script>
-                """
+            """
         Given I have a "public/cat/index.html" file with the body:
             """
             <h1>hello world</h1>
@@ -96,14 +96,14 @@ Feature: Base UI Tests
 
     Scenario: Pagefind UI uses custom highlight query param name
         Given I have a "public/index.html" file with the body:
-                """
+            """
                 <div id="search"></div>
                 <script src="/pagefind/pagefind-ui.js"></script>
 
                 <script>
-                    window.pui = new PagefindUI({ element: "#search", highlightQueryParamName: 'custom-param' });
+                    window.pui = new PagefindUI({ element: "#search", highlightParam: 'custom-param' });
                 </script>
-                """
+            """
         Given I have a "public/cat/index.html" file with the body:
             """
             <h1>hello world</h1>
@@ -132,12 +132,3 @@ Feature: Base UI Tests
             """
         Then There should be no logs
         Then The selector ".pagefind-ui__result-link[href$='?custom-param=hello&custom-param=world']" should contain "hello world"
-        When I evaluate:
-            """
-            async function() {
-                window.pui.triggerSearch("hello world!");
-                await new Promise(r => setTimeout(r, 1500)); // TODO: await el in humane
-            }
-            """
-        Then There should be no logs
-        Then The selector ".pagefind-ui__result-link[href$='?custom-param=hello&custom-param=world%21']" should contain "hello world"

--- a/pagefind/features/ui/ui_hooks.feature
+++ b/pagefind/features/ui/ui_hooks.feature
@@ -13,8 +13,7 @@ Feature: UI Hooks
             <script>
                 window.pui = new PagefindUI({
                     element: "#search",
-                    processTerm: (t) => t.replace("word", "search"),
-                    highlightQueryParamName: null
+                    processTerm: (t) => t.replace("word", "search")
                 });
             </script>
             """

--- a/pagefind_ui/default/svelte/result.svelte
+++ b/pagefind_ui/default/svelte/result.svelte
@@ -1,155 +1,162 @@
 <script>
-  export let show_images = true;
-  export let process_result = null;
-  export let result = { data: async () => {} };
-  export let highlight_query_param = null;
+    export let show_images = true;
+    export let process_result = null;
+    export let result = { data: async () => {} };
 
-  const skipMeta = ["title", "image", "image_alt", "url"];
+    const skipMeta = ["title", "image", "image_alt", "url"];
 
-  let data;
-  let meta = [];
-  const load = async (r) => {
-    data = await r.data();
-    data = process_result?.(data) ?? data;
-    meta = Object.entries(data.meta).filter(([key]) => !skipMeta.includes(key));
-  };
-  $: load(result);
+    let data;
+    let meta = [];
 
-  const placeholder = (max = 30) => {
-    return ". ".repeat(Math.floor(10 + Math.random() * max));
-  };
+    const load = async (r) => {
+        data = await r.data();
+        data = process_result?.(data) ?? data;
+        meta = Object.entries(data.meta).filter(
+            ([key]) => !skipMeta.includes(key)
+        );
+    };
+    $: load(result);
+
+    const placeholder = (max = 30) => {
+        return ". ".repeat(Math.floor(10 + Math.random() * max));
+    };
 </script>
 
 <li class="pagefind-ui__result">
-  {#if data}
-    {#if show_images}
-      <div class="pagefind-ui__result-thumb">
-        {#if data.meta.image}
-          <img
-            class="pagefind-ui__result-image"
-            src={data.meta?.image}
-            alt={data.meta?.image_alt || data.meta?.title}
-          />
+    {#if data}
+        {#if show_images}
+            <div class="pagefind-ui__result-thumb">
+                {#if data.meta.image}
+                    <img
+                        class="pagefind-ui__result-image"
+                        src={data.meta?.image}
+                        alt={data.meta?.image_alt || data.meta?.title}
+                    />
+                {/if}
+            </div>
         {/if}
-      </div>
+        <div class="pagefind-ui__result-inner">
+            <p class="pagefind-ui__result-title">
+                <a
+                    class="pagefind-ui__result-link"
+                    href={data.meta?.url || data.url}
+                    >{data.meta?.title}</a
+                >
+            </p>
+            <p class="pagefind-ui__result-excerpt">{@html data.excerpt}</p>
+            {#if meta.length}
+                <ul class="pagefind-ui__result-tags">
+                    {#each meta as [metaTitle, metaValue]}
+                        <li class="pagefind-ui__result-tag">
+                            {metaTitle.replace(/^(\w)/, (c) =>
+                                c.toLocaleUpperCase()
+                            )}: {metaValue}
+                        </li>
+                    {/each}
+                </ul>
+            {/if}
+        </div>
+    {:else}
+        {#if show_images}
+            <div class="pagefind-ui__result-thumb pagefind-ui__loading" />
+        {/if}
+        <div class="pagefind-ui__result-inner">
+            <p class="pagefind-ui__result-title pagefind-ui__loading">
+                {placeholder(30)}
+            </p>
+            <p class="pagefind-ui__result-excerpt pagefind-ui__loading">
+                {placeholder(40)}
+            </p>
+        </div>
     {/if}
-    <div class="pagefind-ui__result-inner">
-      <p class="pagefind-ui__result-title">
-        <a
-          class="pagefind-ui__result-link"
-          href={(data?.meta?.url || data.url) +
-            (highlight_query_param ? `?${highlight_query_param.toString()}` : "")}
-          >{@html data.meta?.title}</a
-        >
-      </p>
-      <p class="pagefind-ui__result-excerpt">{@html data.excerpt}</p>
-      {#if meta.length}
-        <ul class="pagefind-ui__result-tags">
-          {#each meta as [metaTitle, metaValue]}
-            <li class="pagefind-ui__result-tag">
-              {@html metaTitle.replace(/^(\w)/, (c) => c.toLocaleUpperCase())}: {@html metaValue}
-            </li>
-          {/each}
-        </ul>
-      {/if}
-    </div>
-  {:else}
-    {#if show_images}
-      <div class="pagefind-ui__result-thumb pagefind-ui__loading" />
-    {/if}
-    <div class="pagefind-ui__result-inner">
-      <p class="pagefind-ui__result-title pagefind-ui__loading">
-        {placeholder(30)}
-      </p>
-      <p class="pagefind-ui__result-excerpt pagefind-ui__loading">
-        {placeholder(40)}
-      </p>
-    </div>
-  {/if}
 </li>
 
 <style>
-  .pagefind-ui__result {
-    list-style-type: none;
-    display: flex;
-    align-items: flex-start;
-    gap: min(calc(40px * var(--pagefind-ui-scale)), 3%);
-    padding: calc(30px * var(--pagefind-ui-scale)) 0
-      calc(40px * var(--pagefind-ui-scale));
-    border-top: solid var(--pagefind-ui-border-width) var(--pagefind-ui-border);
-  }
-  .pagefind-ui__result:last-of-type {
-    border-bottom: solid var(--pagefind-ui-border-width)
-      var(--pagefind-ui-border);
-  }
-  .pagefind-ui__result-thumb {
-    width: min(30%, calc((30% - (100px * var(--pagefind-ui-scale))) * 100000));
-    max-width: calc(120px * var(--pagefind-ui-scale));
-    margin-top: calc(10px * var(--pagefind-ui-scale));
-    aspect-ratio: var(--pagefind-ui-image-box-ratio);
-    position: relative;
-  }
-  .pagefind-ui__result-image {
-    display: block;
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    font-size: 0;
-    width: auto;
-    height: auto;
-    max-width: 100%;
-    max-height: 100%;
-    border-radius: var(--pagefind-ui-image-border-radius);
-  }
-  .pagefind-ui__result-inner {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    margin-top: calc(10px * var(--pagefind-ui-scale));
-  }
-  .pagefind-ui__result-title {
-    display: inline-block;
-    font-weight: 700;
-    font-size: calc(21px * var(--pagefind-ui-scale));
-    margin-top: 0;
-    margin-bottom: 0;
-  }
-  .pagefind-ui__result-title .pagefind-ui__result-link {
-    color: var(--pagefind-ui-text);
-    text-decoration: none;
-  }
-  .pagefind-ui__result-title .pagefind-ui__result-link:hover {
-    text-decoration: underline;
-  }
-  .pagefind-ui__result-excerpt {
-    display: inline-block;
-    font-weight: 400;
-    font-size: calc(16px * var(--pagefind-ui-scale));
-    margin-top: calc(4px * var(--pagefind-ui-scale));
-    margin-bottom: 0;
-    min-width: calc(250px * var(--pagefind-ui-scale));
-  }
-  .pagefind-ui__loading {
-    color: var(--pagefind-ui-text);
-    background-color: var(--pagefind-ui-text);
-    border-radius: var(--pagefind-ui-border-radius);
-    opacity: 0.1;
-    pointer-events: none;
-  }
-  .pagefind-ui__result-tags {
-    list-style-type: none;
-    padding: 0;
-    display: flex;
-    gap: calc(20px * var(--pagefind-ui-scale));
-    flex-wrap: wrap;
-    margin-top: calc(20px * var(--pagefind-ui-scale));
-  }
-  .pagefind-ui__result-tag {
-    padding: calc(4px * var(--pagefind-ui-scale))
-      calc(8px * var(--pagefind-ui-scale));
-    font-size: calc(14px * var(--pagefind-ui-scale));
-    border-radius: var(--pagefind-ui-border-radius);
-    background-color: var(--pagefind-ui-tag);
-  }
+    .pagefind-ui__result {
+        list-style-type: none;
+        display: flex;
+        align-items: flex-start;
+        gap: min(calc(40px * var(--pagefind-ui-scale)), 3%);
+        padding: calc(30px * var(--pagefind-ui-scale)) 0
+            calc(40px * var(--pagefind-ui-scale));
+        border-top: solid var(--pagefind-ui-border-width)
+            var(--pagefind-ui-border);
+    }
+    .pagefind-ui__result:last-of-type {
+        border-bottom: solid var(--pagefind-ui-border-width)
+            var(--pagefind-ui-border);
+    }
+    .pagefind-ui__result-thumb {
+        width: min(
+            30%,
+            calc((30% - (100px * var(--pagefind-ui-scale))) * 100000)
+        );
+        max-width: calc(120px * var(--pagefind-ui-scale));
+        margin-top: calc(10px * var(--pagefind-ui-scale));
+        aspect-ratio: var(--pagefind-ui-image-box-ratio);
+        position: relative;
+    }
+    .pagefind-ui__result-image {
+        display: block;
+        position: absolute;
+        left: 50%;
+        transform: translateX(-50%);
+        font-size: 0;
+        width: auto;
+        height: auto;
+        max-width: 100%;
+        max-height: 100%;
+        border-radius: var(--pagefind-ui-image-border-radius);
+    }
+    .pagefind-ui__result-inner {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        margin-top: calc(10px * var(--pagefind-ui-scale));
+    }
+    .pagefind-ui__result-title {
+        display: inline-block;
+        font-weight: 700;
+        font-size: calc(21px * var(--pagefind-ui-scale));
+        margin-top: 0;
+        margin-bottom: 0;
+    }
+    .pagefind-ui__result-title .pagefind-ui__result-link {
+        color: var(--pagefind-ui-text);
+        text-decoration: none;
+    }
+    .pagefind-ui__result-title .pagefind-ui__result-link:hover {
+        text-decoration: underline;
+    }
+    .pagefind-ui__result-excerpt {
+        display: inline-block;
+        font-weight: 400;
+        font-size: calc(16px * var(--pagefind-ui-scale));
+        margin-top: calc(4px * var(--pagefind-ui-scale));
+        margin-bottom: 0;
+        min-width: calc(250px * var(--pagefind-ui-scale));
+    }
+    .pagefind-ui__loading {
+        color: var(--pagefind-ui-text);
+        background-color: var(--pagefind-ui-text);
+        border-radius: var(--pagefind-ui-border-radius);
+        opacity: 0.1;
+        pointer-events: none;
+    }
+    .pagefind-ui__result-tags {
+        list-style-type: none;
+        padding: 0;
+        display: flex;
+        gap: calc(20px * var(--pagefind-ui-scale));
+        flex-wrap: wrap;
+        margin-top: calc(20px * var(--pagefind-ui-scale));
+    }
+    .pagefind-ui__result-tag {
+        padding: calc(4px * var(--pagefind-ui-scale))
+            calc(8px * var(--pagefind-ui-scale));
+        font-size: calc(14px * var(--pagefind-ui-scale));
+        border-radius: var(--pagefind-ui-border-radius);
+        background-color: var(--pagefind-ui-tag);
+    }
 </style>

--- a/pagefind_ui/default/svelte/result_with_subs.svelte
+++ b/pagefind_ui/default/svelte/result_with_subs.svelte
@@ -2,8 +2,6 @@
   export let show_images = true;
   export let process_result = null;
   export let result = { data: async () => {} };
-  // string or null
-  export let highlight_query_param = null;
 
   const skipMeta = ["title", "image", "image_alt", "url"];
 
@@ -28,12 +26,10 @@
   const load = async (r) => {
     data = await r.data();
     data = process_result?.(data) ?? data;
-    meta = Object.entries(data?.meta).filter(
-      ([key]) => !skipMeta.includes(key)
-    );
+    meta = Object.entries(data.meta).filter(([key]) => !skipMeta.includes(key));
     if (Array.isArray(data.sub_results)) {
       has_root_sub_result =
-        data.sub_results?.[0]?.url === (data?.meta?.url || data?.url);
+        data.sub_results?.[0]?.url === (data.meta?.url || data.url);
       if (has_root_sub_result) {
         non_root_sub_results = thin_sub_results(data.sub_results.slice(1), 3);
       } else {
@@ -63,11 +59,8 @@
     {/if}
     <div class="pagefind-ui__result-inner">
       <p class="pagefind-ui__result-title">
-        <a
-          class="pagefind-ui__result-link"
-              href={(data?.meta?.url || data.url) +
-            (highlight_query_param ? `?${highlight_query_param.toString()}` : "")}
-          >{@html data.meta?.title}</a
+        <a class="pagefind-ui__result-link" href={data.meta?.url || data.url}
+          >{data.meta?.title}</a
         >
       </p>
       {#if has_root_sub_result}
@@ -77,11 +70,8 @@
       {#each non_root_sub_results as subres}
         <div class="pagefind-ui__result-nested">
           <p class="pagefind-ui__result-title">
-            <a
-              class="pagefind-ui__result-link"
-              href={subres.url +
-                (highlight_query_param ? `?${highlight_query_param}` : "")}
-              >{@html subres.title}</a
+            <a class="pagefind-ui__result-link" href={subres.url}
+              >{subres.title}</a
             >
           </p>
           <p class="pagefind-ui__result-excerpt">{@html subres.excerpt}</p>
@@ -92,7 +82,7 @@
         <ul class="pagefind-ui__result-tags">
           {#each meta as [metaTitle, metaValue]}
             <li class="pagefind-ui__result-tag">
-              {@html metaTitle.replace(/^(\w)/, (c) => c.toLocaleUpperCase())}: {@html metaValue}
+              {metaTitle.replace(/^(\w)/, (c) => c.toLocaleUpperCase())}: {metaValue}
             </li>
           {/each}
         </ul>

--- a/pagefind_ui/default/svelte/ui.svelte
+++ b/pagefind_ui/default/svelte/ui.svelte
@@ -34,9 +34,6 @@
   export let merge_index = [];
   export let trigger_search_term = "";
   export let translations = {};
-  // this is the name of the query param which is used to highlight the search terms after the user has navigated to a result page
-  // consider exposing the prop in the constructor in camelCase if needed
-  export let highlight_query_param_name = "pagefind-highlight";
 
   let val = "";
   $: if (trigger_search_term) {
@@ -44,16 +41,6 @@
     trigger_search_term = "";
   }
 
-  // this could be changed to not split if the value is quoted
-  // ex: val = `hello world "foo bar"` highlightWords = ["hello", "world", "foo bar"]
-
-  $: highlightWords = val.split(" ");
-
-  $: highlight_query_param = new URLSearchParams(
-    highlightWords.map((word) => {
-      return [highlight_query_param_name, word];
-    })
-  ).toString();
   let pagefind;
   let input_el,
     clear_el,
@@ -318,23 +305,9 @@
             <ol class="pagefind-ui__results">
               {#each searchResult.results.slice(0, show) as result (result.id)}
                 {#if show_sub_results}
-                  <ResultWithSubs
-                    {show_images}
-                    {process_result}
-                    {result}
-                    highlight_query_param={highlight_query_param_name
-                      ? highlight_query_param
-                      : null}
-                  />
+                  <ResultWithSubs {show_images} {process_result} {result} />
                 {:else}
-                  <Result
-                    {show_images}
-                    {process_result}
-                    {result}
-                    highlight_query_param={highlight_query_param_name
-                      ? highlight_query_param
-                      : null}
-                  />
+                  <Result {show_images} {process_result} {result} />
                 {/if}
               {/each}
             </ol>

--- a/pagefind_ui/default/ui-core.js
+++ b/pagefind_ui/default/ui-core.js
@@ -26,11 +26,6 @@ export class PagefindUI {
     let debounceTimeoutMs = opts.debounceTimeoutMs ?? 300;
     let mergeIndex = opts.mergeIndex ?? [];
     let translations = opts.translations ?? [];
-    // setting the param to null should disable highlighting, hence this more complicated check
-    let highlightQueryParamName = "pagefind-highlight";
-    if (opts.highlightQueryParamName !== undefined) {
-      highlightQueryParamName = opts.highlightQueryParamName;
-    }
 
     // Remove the UI-specific config before passing it along to the Pagefind backend
     delete opts["element"];
@@ -67,7 +62,6 @@ export class PagefindUI {
           debounce_timeout_ms: debounceTimeoutMs,
           merge_index: mergeIndex,
           translations,
-          highlight_query_param_name: highlightQueryParamName,
           pagefind_options: opts,
         },
       });

--- a/pagefind_web_js/lib/highlight.ts
+++ b/pagefind_web_js/lib/highlight.ts
@@ -12,13 +12,13 @@ import Mark from "mark.js";
 
 type pagefindHighlightOptions = {
   markContext?: string | HTMLElement | HTMLElement[] | NodeList | null;
-  pagefindQueryParamName?: string;
+  highlightParam?: string;
   markOptions?: Omit<Mark.MarkOptions, "separateWordSearch">;
   addStyles?: boolean;
 };
 
 export default class PagefindHighlight {
-  pagefindQueryParamName: string;
+  highlightParam: string;
   markContext: string | HTMLElement | HTMLElement[] | NodeList | null;
   markOptions: Mark.MarkOptions;
   addStyles: boolean;
@@ -26,7 +26,7 @@ export default class PagefindHighlight {
   constructor(
     options: pagefindHighlightOptions = {
       markContext: null,
-      pagefindQueryParamName: "pagefind-highlight",
+      highlightParam: "pagefind-highlight",
       markOptions: {
         className: "pagefind-highlight",
         exclude: ["[data-pagefind-ignore]", "[data-pagefind-ignore] *"],
@@ -34,11 +34,11 @@ export default class PagefindHighlight {
       addStyles: true,
     }
   ) {
-    const { pagefindQueryParamName, markContext, markOptions, addStyles } =
+    const { highlightParam, markContext, markOptions, addStyles } =
       options;
 
-    this.pagefindQueryParamName =
-      pagefindQueryParamName ?? "pagefind-highlight";
+    this.highlightParam =
+      highlightParam ?? "pagefind-highlight";
     this.addStyles = addStyles ?? true;
     this.markContext = markContext !== undefined ? markContext : null;
     this.markOptions =
@@ -92,7 +92,7 @@ export default class PagefindHighlight {
   }
 
   highlight() {
-    const params = this.getHighlightParams(this.pagefindQueryParamName);
+    const params = this.getHighlightParams(this.highlightParam);
     if (!params || params.length === 0) return;
     this.addStyles &&
       this.addHighlightStyles(this.markOptions.className as string);

--- a/pagefind_web_js/types/index.d.ts
+++ b/pagefind_web_js/types/index.d.ts
@@ -21,6 +21,10 @@ declare global {
          * Only applies in multisite setups.
          */
         mergeFilter?: Object,
+        /** 
+         * If set, will ass the search term as a query parameter under this key, for use with Pagefind's highlighting script.
+         */
+        highlightParam?: string,
         language?: string,
         /**
          * Whether an instance of Pagefind is the primary index or not (for multisite).


### PR DESCRIPTION
Follow on from #425 

- Moves logic out of the Default UI and into the underlying JS API
  - Makes it available for users beyond the Default UI, and also fixes some issues with the previous string handling of the URL when combining this feature and subresults, or existing query parameters
- Changes query parameters to opt-in rather than opt-out to eliminate the breaking change to URLs
- Adjusts the documentation to match