### PR TITLE
Add ko.json to support Korean localization

### DIFF
--- a/pagefind_ui/translations/ko.json
+++ b/pagefind_ui/translations/ko.json
@@ -1,0 +1,18 @@
+{
+    "thanks_to": "Seokho Son <https://github.com/seokho-son>",
+    "comments": "",
+    "direction": "ltr",
+    "strings": {
+        "placeholder": "검색어",
+        "clear_search": "비우기",
+        "load_more": "검색 결과 더 보기",
+        "search_label": "사이트 검색",
+        "filters_label": "필터",
+        "zero_results": "[SEARCH_TERM]에 대한 결과 없음",
+        "many_results": "[SEARCH_TERM]에 대한 결과 [COUNT]건",
+        "one_result": "[SEARCH_TERM]에 대한 결과 [COUNT]건",
+        "alt_search": "[SEARCH_TERM]에 대한 결과 없음. [DIFFERENT_TERM]에 대한 결과",
+        "search_suggestion": "[SEARCH_TERM]에 대한 결과 없음. 추천 검색어: ",
+        "searching": "[SEARCH_TERM] 검색 중..."
+    }
+}


### PR DESCRIPTION
Hello maintainers! 
Thanks for this nice project. 

I am one of the maintainers of the [CNCF Cloud Native Glossary Project](https://github.com/cncf/glossary) 

We are trying to apply the PageFind to our website.

It seems Korean UI strings are not supported yet. Hope to add Korean ko.json.

Please note that I am a native Korean and contributing to several Korean localization projects. :)