### PR TITLE
Be more careful about special-casing `index.html`

### DIFF
--- a/pagefind/src/fossick/mod.rs
+++ b/pagefind/src/fossick/mod.rs
@@ -486,6 +486,16 @@ impl Fossicker {
     }
 }
 
+fn strip_index_html(url: &str) -> &str {
+    if url.ends_with("/index.html") {
+        &url[..url.len() - 10]
+    } else if url == "index.html" {
+        ""
+    } else {
+        url
+    }
+}
+
 fn build_url(page_url: &Path, relative_to: Option<&Path>, options: &SearchOptions) -> String {
     let prefix = relative_to.unwrap_or(&options.site_source);
 
@@ -503,7 +513,7 @@ fn build_url(page_url: &Path, relative_to: Option<&Path>, options: &SearchOption
     };
 
     let final_url: String = if !options.keep_index_url {
-        url.to_slash_lossy().to_owned().replace("index.html", "")
+        strip_index_html(&url.to_slash_lossy()).to_string()
     } else {
         url.to_slash_lossy().to_owned().to_string()
     };


### PR DESCRIPTION
Pagefind has code to strip a trailing `index.html` from a URL. The intention is obviously to avoid showing `/folder/index.html` when `/folder/` would already do.

However, the code is a bit lax about checking that `index.html` is the _full_ file name: It would also strip that suffix for, say, `/folder/my_index.html`. That, however, leads to a broken link...

I noticed this because I want to convert https://git-scm.com/ to use Pagefind, but any search hitting `/docs/git-checkout-index.html` would mistakenly link to `/docs/git-checkout-`.