### PR TITLE
make the config argument for the createIndex optional

### DIFF
--- a/wrappers/node/types/index.d.ts
+++ b/wrappers/node/types/index.d.ts
@@ -1,7 +1,7 @@
 /**
  * Create a new Pagefind index that files can be added to
  */
-export function createIndex(config: PagefindServiceConfig): Promise<NewIndexResponse>;
+export function createIndex(config?: PagefindServiceConfig): Promise<NewIndexResponse>;
 
 /**
  * Close the Pagefind service and clean up, stopping the binary altogether.


### PR DESCRIPTION
The config argument is optional in the [source code](https://github.com/CloudCannon/pagefind/blob/38f90542921b405f5cadabd0110a483371581934/wrappers/node/lib/index.js/#L41), however is required in the type definitions. This pull request makes it optional in the second one.