### PR TITLE
docs(wrappers/node): correct example `HTMLFile.path` -> `.sourcePath`

### DIFF
--- a/wrappers/node/types/index.d.ts
+++ b/wrappers/node/types/index.d.ts
@@ -82,7 +82,7 @@ declare function addDirectory(path: SiteDirectory): Promise<IndexingResponse>;
  * The data required for Pagefind to index an HTML file that isn't on disk
  * @example
  * {
- *   path: "about/index.html",
+ *   sourcePath: "about/index.html",
  *   content: "<html lang='en'><body><h1>Meet the team</h1></body></html>"
  * }
  */


### PR DESCRIPTION
Note that the `HTMLFile` definition does not have a `path` key, but it does have a `sourcePath` key.