### PR TITLE
add korean entry to multilingual page in docs

### DIFF
--- a/docs/content/docs/multilingual.md
+++ b/docs/content/docs/multilingual.md
@@ -48,6 +48,7 @@ If word stemming is unsupported, search results won't match across root words. I
 | Irish — `ga`      | ❌               | ✅             |
 | Italian — `it`    | ✅               | ✅             |
 | Japanese — `ja`   | ✅               | See below     |
+| Korean — `ko`     | ✅               | See below     |
 | Lithuanian — `lt` | ❌               | ✅             |
 | Māori — `mi`      | ✅               | ❌             |
 | Nepali — `ne`     | ❌               | ✅             |

--- a/docs/content/docs/multilingual.md
+++ b/docs/content/docs/multilingual.md
@@ -48,7 +48,7 @@ If word stemming is unsupported, search results won't match across root words. I
 | Irish — `ga`      | ❌               | ✅             |
 | Italian — `it`    | ✅               | ✅             |
 | Japanese — `ja`   | ✅               | See below     |
-| Korean — `ko`     | ✅               | See below     |
+| Korean — `ko`     | ✅               | ❌             |
 | Lithuanian — `lt` | ❌               | ✅             |
 | Māori — `mi`      | ✅               | ❌             |
 | Nepali — `ne`     | ❌               | ✅             |


### PR DESCRIPTION
Hi, was checking for the Korean language support in the docs but couldn't find any mentions of it, then found https://github.com/CloudCannon/pagefind/pull/583 in PRs which wasn't reflected in the docs.


Note: not sure about the "word stemming", please let me know if "See below" is appropriate here.

Thank you!