### PR TITLE
Minor addition to the Getting Started documentation to prevent confusion around languages and result ids.

### DIFF
--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -63,3 +63,7 @@ Loading this in your browser, you should see a search input on your page. Try se
 The last required step is to run Pagefind after building your site on your CMS or hosting platform. If you're a CloudCannon user, add a [`.cloudcannon/postbuild`](https://cloudcannon.com/documentation/articles/extending-your-build-process-with-hooks/) file containing the npx command above (minus the `--serve` flag). For other platforms, set up an equivalent command to run after your site build — the end goal is that Pagefind will run after every build of your site before it is deployed.
 
 For many use cases, you can stop here and mark it as complete. Or, you can dive deeper into Pagefind and configure it to your liking — check out [Configuring the index](/docs/indexing/) for some next steps.
+
+## Notes
+
+> For optimal performance, ensure the `lang` attribute is set on your `html` element. See [Multilingual Search](/docs/multilingual) for more details.

--- a/docs/content/docs/api.md
+++ b/docs/content/docs/api.md
@@ -58,7 +58,7 @@ This will return an object with the following structure:
 { 
     results: [
         {
-            id: "6fceec9",
+            id: "en_6fceec9",
             data: async function data()
         }
     ]
@@ -66,6 +66,8 @@ This will return an object with the following structure:
 ```
 
 At this point you will have access to the number of search results, and a unique ID for each result. Also see [Debounced search](#debounced-search) below for an alternative API.
+
+> Note that the prefix `en` in `en_6fceec9` matches the `lang` attribute of your `html` element. If `lang` is not set, the prefix defaults to `unknown`. See [Multilingual Search](/docs/multilingual) for more details.
 
 ## Loading a result
 


### PR DESCRIPTION
Following my confusion around `result` `id`s discussed in cloudcannon/pagefind#371, this PR adds a few short notes to the docs that would have precluded my confusion.