### PR TITLE
Fix HTML encoding bug with inline metadata

### DIFF
--- a/pagefind/integration_tests/characters/pagefind-handles-html-entities-in-inline-meta.toolproof.yml
+++ b/pagefind/integration_tests/characters/pagefind-handles-html-entities-in-inline-meta.toolproof.yml
@@ -1,0 +1,29 @@
+name: Character Tests > Pagefind handles HTML entities in inline meta
+steps:
+  - ref: ./background.toolproof.yml
+  - step: I have a "public/apiary/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html lang="en"><head></head><body><h1
+      data-pagefind-meta="title:The &quot;bees&quot;">the bees</h1></body></html>
+  - macro: I run Pagefind
+  - step: stdout should contain "Running Pagefind"
+  - step: The file "public/pagefind/pagefind.js" should not be empty
+  - step: I serve the directory "public"
+  - step: In my browser, I load "/"
+  - step: In my browser, I evaluate {js}
+    js: >-
+      let pagefind = await import("/pagefind/pagefind.js");
+
+
+      let search = await pagefind.search("bees");
+
+
+      let pages = await Promise.all(search.results.map(r => r.data()));
+
+      document.querySelector('[data-result]').innerText = pages.map(p =>
+      p.meta.title).join(", ");
+  - step: In my browser, the console should be empty
+  - step: In my browser, I evaluate {js}
+    js: |-
+      let val = await toolproof.querySelector("[data-result]");
+      toolproof.assert_eq(val.innerHTML, `The "bees"`);

--- a/pagefind/src/fossick/parser.rs
+++ b/pagefind/src/fossick/parser.rs
@@ -646,7 +646,7 @@ fn parse_attr_string(input: String, el: &Element) -> Vec<String> {
 impl DomParsingNode {
     fn get_attribute_pair(&self, input: &str) -> Option<(String, String)> {
         match input.split_once(':') {
-            Some((filter, value)) => Some((filter.to_owned(), value.to_owned())),
+            Some((filter, value)) => Some((filter.to_owned(), normalize_content(&value))),
             None => {
                 if self.current_value.is_empty() {
                     None


### PR DESCRIPTION
For #743 