### PR TITLE
GetIndexCatalogue instruction

### DIFF
--- a/pagefind/src/service/api.rs
+++ b/pagefind/src/service/api.rs
@@ -41,7 +41,7 @@ use std::{collections::BTreeMap, path::PathBuf};
 use crate::{
     fossick::{parser::DomParserResult, Fossicker},
     options::PagefindServiceConfig,
-    PagefindInboundConfig, SearchOptions, SearchState,
+    PagefindInboundConfig, SearchOptions, SearchState, IndexCatalogueRepresentation,
 };
 
 #[derive(Debug)]
@@ -207,6 +207,14 @@ impl PagefindIndex {
     pub async fn get_files(&mut self) -> Result<Vec<SyntheticFile>> {
         self.search_index.build_indexes().await?;
         Ok(self.search_index.get_files().await)
+    }
+
+    /// Get the catalogue mappings from hashes to encoded data.
+    ///
+    /// # Returns
+    /// An IndexCatalogueRepresentation containing the hash and content of each fragment.
+    pub async fn get_index_catalogue(&mut self) -> Result<IndexCatalogueRepresentation> {
+        self.search_index.get_index_catalogue().await
     }
 }
 

--- a/pagefind/src/service/mod.rs
+++ b/pagefind/src/service/mod.rs
@@ -222,6 +222,19 @@ pub async fn run_service() {
                     }
                 }
             }
+            RequestAction::GetIndexCatalogue { index_id } => {
+                if let Some(index) = get_index(&mut indexes, index_id, err) {
+                    match index.get_index_catalogue().await {
+                        Ok(index_catalogue) => {
+                            send(ResponseAction::GetIndexCatalogue {
+                                entry_count: index_catalogue.entries.len(),
+                                entries: index_catalogue.entries,
+                            })
+                        }
+                        Err(e) => err(&e.to_string()),
+                    }
+                }
+            }
             RequestAction::GetFiles { index_id } => {
                 if let Some(index) = get_index(&mut indexes, index_id, err) {
                     match index.build_indexes().await {

--- a/pagefind/src/service/requests.rs
+++ b/pagefind/src/service/requests.rs
@@ -46,6 +46,9 @@ pub(super) enum RequestAction {
     GetFiles {
         index_id: u32,
     },
+    GetIndexCatalogue {
+        index_id: u32,
+    },
     DeleteIndex {
         index_id: u32,
     },

--- a/pagefind/src/service/responses.rs
+++ b/pagefind/src/service/responses.rs
@@ -33,6 +33,10 @@ pub(super) enum ResponseAction {
     GetFiles {
         files: Vec<SyntheticFileResponse>,
     },
+    GetIndexCatalogue {
+        entries: Vec<(String, String)>,
+        entry_count: usize,
+    },
     DeleteIndex {},
 }
 

--- a/wrappers/node/lib/index.js
+++ b/wrappers/node/lib/index.js
@@ -96,6 +96,7 @@ const indexFns = (indexId) => {
         addDirectory: (dir) => addDirectory(indexId, dir),
         writeFiles: (options) => writeFiles(indexId, options),
         getFiles: () => getFiles(indexId),
+        getIndexCatalogue: () => getIndexCatalogue(indexId),
         deleteIndex: () => deleteIndex(indexId)
     }
 }
@@ -269,6 +270,36 @@ const getFiles = (indexId) => new Promise((resolve, reject) => {
                             content: decode(file.content)
                         }
                     })
+                }
+            };
+            handleApiResponse(resolve, reject, response, successCallback);
+        }
+    );
+});
+
+/**
+ * @typedef {import ('pagefindService').GetIndexCatalogueResponse} GetIndexCatalogueResponse
+ * 
+ * @param {number} indexId 
+ * @returns {Promise<GetIndexCatalogueResponse>}
+ */
+const getIndexCatalogue = (indexId) => new Promise((resolve, reject) => {
+    const action = 'GetIndexCatalogue';
+    launch().sendMessage(
+        {
+            type: action,
+            index_id: indexId,
+        }, (response) => {
+            /** @type {function(InternalResponsePayload): Omit<GetIndexCatalogueResponse, 'errors'>?} */
+            const successCallback = (success) => {
+                if (success.type !== action) {
+                    reject(`Message returned from backend should have been ${action}, but was ${success.type}`);
+                    return null;
+                }
+
+                return {
+                    entries: success.entries,
+                    entryCount: success.entry_count
                 }
             };
             handleApiResponse(resolve, reject, response, successCallback);


### PR DESCRIPTION
Only recently came to pagefind and it is amazing, thank you!

As in #371, my use-case is geospatial, and using pagefind for text search works really well except that I really need to be able to filter by a map-window. In short, we have 30-60k records to search and while leaflet.js cluster markers can handle that, geographically windowing the search is critical for the tool to be usable.

*Is this an XY problem?*: The two ideas I had were, (1) adding a (taxonomy-based) locality filter, but the reality is that would be hard to do in a useful way given how many localities there are and unintuitive, (2) searching the full result set with the geographic window (thanks @indus for highlighting flatbush) and intersecting the results. The second does work, but without being able to map pagefind hashes to any lookup outside pagefind, that means loading all matching results via `result.data()` and using metadata. I cannot take the first `N` results because they may not contain `O(N)` matches in the geospatial window - users are likely to wish to search very generic terms in a very small area, so loading every fragment to filter down to 5 results generates a huge amount of traffic and kills the browser. As such, the minimum viable option seems to be adding `GetIndexCatalogue`  so that I can  flathub results to pagefind results

