### PR TITLE
feat: :sparkles: add option to hide images on result template

### DIFF
--- a/pagefind_ui/modular/README.md
+++ b/pagefind_ui/modular/README.md
@@ -111,6 +111,7 @@ instance.add(new ResultList({
 | Option                | Description                                                               |
 |-----------------------|---------------------------------------------------------------------------|
 | `containerElement`    | A selector to an element that the results should be placed within         |
+| `showImages`          | Whether to show images in the results. Defaults to `true`                 |
 | `placeholderTemplate` | A function that returns the template for a result that has not yet loaded |
 | `resultTemplate`      | A function that returns the template for a search result                  |
 

--- a/pagefind_ui/modular/components/resultList.js
+++ b/pagefind_ui/modular/components/resultList.js
@@ -28,15 +28,16 @@ const placeholderTemplate = () => {
 </li>`;
 }
 
-const resultTemplate = (result) => {
+const resultTemplate = (result, showImages) => {
     let wrapper = new El("li").class("pagefind-modular-list-result");
-
-    let thumb = new El("div").class("pagefind-modular-list-thumb").addTo(wrapper);
-    if (result?.meta?.image) {
-        new El("img").class("pagefind-modular-list-image").attrs({
-            src: result.meta.image,
-            alt: result.meta.image_alt || result.meta.title
-        }).addTo(thumb);
+    if(showImages) {
+        let thumb = new El("div").class("pagefind-modular-list-thumb").addTo(wrapper);
+        if (result?.meta?.image) {
+            new El("img").class("pagefind-modular-list-image").attrs({
+                src: result.meta.image,
+                alt: result.meta.image_alt || result.meta.title
+            }).addTo(thumb);
+        }
     }
 
     let inner = new El("div").class("pagefind-modular-list-inner").addTo(wrapper);
@@ -68,6 +69,7 @@ class Result {
         this.placeholderNodes = opts.placeholderNodes;
         this.resultFn = opts.resultFn;
         this.intersectionEl = opts.intersectionEl;
+        this.showImages = opts.showImages;
         this.result = null;
         this.waitForIntersection();
     }
@@ -96,7 +98,7 @@ class Result {
         if (!this.placeholderNodes?.length) return;
 
         this.result = await this.rawResult.data();
-        const resultTemplate = this.resultFn(this.result);
+        const resultTemplate = this.resultFn(this.result, this.showImages);
         const resultNodes = templateNodes(resultTemplate);
 
         while (this.placeholderNodes.length > 1) {
@@ -114,6 +116,7 @@ export class ResultList {
         this.results = [];
         this.placeholderTemplate = opts.placeholderTemplate ?? placeholderTemplate;
         this.resultTemplate = opts.resultTemplate ?? resultTemplate;
+        this.showImages = opts.showImages ?? true;
 
         if (opts.containerElement) {
             this.initContainer(opts.containerElement);
@@ -147,7 +150,7 @@ export class ResultList {
             this.results = results.results.map(r => {
                 let placeholderNodes = templateNodes(this.placeholderTemplate());
                 this.append(placeholderNodes);
-                return new Result({ result: r, placeholderNodes, resultFn: this.resultTemplate, intersectionEl: this.intersectionEl });
+                return new Result({ result: r, placeholderNodes, resultFn: this.resultTemplate, intersectionEl: this.intersectionEl, showImages: this.showImages });
             })
         });
 


### PR DESCRIPTION
This update introduces a (new) flag that allows users to hide the thumb, similar to the existing functionality in the defaultUI.

While I know it's possible to remove the image by providing a custom template (or via CSS), this flag is simple enough in my opinion without much overheat.

Given its ease of use, I believe it will be a valuable addition to the current options.

Cheers
Hannes
