### PR TITLE
python: Write WHEEL tags in expanded form

### DIFF
--- a/wrappers/python/scripts/build/binary_only_wheel.py
+++ b/wrappers/python/scripts/build/binary_only_wheel.py
@@ -143,10 +143,10 @@ def write_wheel(
     # see https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#compressed-tag-sets
     expanded_tags = []
     pytag, abitag, platformtag = tag.split("-")
-    for x in pytag.split('.'):
-        for y in abitag.split('.'):
-            for z in platformtag.split('.'):
-                expanded_tags.append('-'.join((x, y, z)))
+    for x in pytag.split("."):
+        for y in abitag.split("."):
+            for z in platformtag.split("."):
+                expanded_tags.append("-".join((x, y, z)))
 
     return write_wheel_file(
         (out_dir / wheel_name),


### PR DESCRIPTION
Hello, pip maintainer here. :wave: 

The wheel specification requires that the `Tag` field in `.dist-info/WHEEL` contains all of the tags in their expanded form. Leaving the compressed form unchanged is usually "fine", but pip (check only!) misidentifies the wheel as incompatible with the system when fed a compressed wheel tag set. We just got a bug report about this: https://github.com/pypa/pip/issues/13709

- https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#compressed-tag-sets
- point 11 under "file contents" in https://packaging.python.org/en/latest/specifications/binary-distribution-format/#file-contents

While I'm unfamiliar with this repository and can't test the build script directly, the tag expansion logic has been tested below (it also comes from the specification FWIW).

```pycon
Python 3.14.2 (main, Dec 18 2025, 12:16:31) [GCC 15.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> def expand(tag):
...     pytag, abitag, platformtag = tag.split("-")
...     for x in pytag.split('.'):
...         for y in abitag.split('.'):
...             for z in platformtag.split('.'):
...                 yield '-'.join((x, y, z))
...                 
>>> list(expand("py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64"))
['py3-none-manylinux_2_17_aarch64', 'py3-none-manylinux2014_aarch64', 'py3-none-musllinux_1_1_aarch64']
>>> 
```