### PR TITLE
Improve both filesize & performance of the indexing binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,8 @@
 members = ["pagefind", "pagefind_stem"]
 exclude = ["pagefind_web"]
 resolver = "2"
+
+[profile.release]
+opt-level = "s"
+lto = true
+strip = true


### PR DESCRIPTION
Forgot this had been configured for the wasm builds but not the indexing build. This cuts ~10MB off the binary size, and indexes my giant test site in ~50s instead of ~60s. So win-win.