### PR TITLE
Add proper support for diacritics in Pagefind's indexing and ranking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,18 +409,18 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -944,11 +944,11 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "emojis"
-version = "0.6.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e1f1df1f181f2539bac8bf027d31ca5ffbf9e559e3f2d09413b9107b5c02f4"
+checksum = "f52f3d011046a013bdefbc63a5523b06ad0c0f1e227941baf98475496229d634"
 dependencies = [
- "phf 0.11.3",
+ "phf 0.12.1",
 ]
 
 [[package]]
@@ -2152,22 +2152,22 @@ dependencies = [
 
 [[package]]
 name = "minicbor"
-version = "0.19.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7005aaf257a59ff4de471a9d5538ec868a21586534fff7f85dd97d4043a6139"
+checksum = "f9a1119e42fbacc2bb65d860de6eb7c930562bc71d42dca026d06b0228231f77"
 dependencies = [
  "minicbor-derive",
 ]
 
 [[package]]
 name = "minicbor-derive"
-version = "0.13.0"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1154809406efdb7982841adb6311b3d095b46f78342dd646736122fe6b19e267"
+checksum = "50fcf6ee04e942da7d65066bf427fe7bdd229256998809eeecee25db6dc9aac2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2296,6 +2296,7 @@ dependencies = [
  "tokio",
  "twelf",
  "typed-builder",
+ "unicode-normalization",
  "unicode-segmentation",
  "wax",
 ]
@@ -2366,6 +2367,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
+]
+
+[[package]]
 name = "phf_codegen"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2433,6 +2443,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher 1.0.1",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher 1.0.1",
 ]
@@ -3510,18 +3529,18 @@ dependencies = [
 
 [[package]]
 name = "typed-builder"
-version = "0.20.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9d30e3a08026c78f246b173243cf07b3696d274debd26680773b6773c2afc7"
+checksum = "fef81aec2ca29576f9f6ae8755108640d0a86dd3161b2e8bca6cfa554e98f77d"
 dependencies = [
  "typed-builder-macro",
 ]
 
 [[package]]
 name = "typed-builder-macro"
-version = "0.20.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c36781cc0e46a83726d9879608e4cf6c2505237e263a8eb8c24502989cfdb28"
+checksum = "1ecb9ecf7799210407c14a8cfdfe0173365780968dc57973ed082211958e0b18"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/docs/content/docs/ranking.md
+++ b/docs/content/docs/ranking.md
@@ -124,3 +124,24 @@ await pagefind.options({
 - The minimum value is `0.0`, where terms will saturate immediately and results will not distinguish between one term and many.
 
 Decreasing the `termSaturation` parameter is a good way to suppress pages that are ranking well due to an extremely high number of search terms existing in their content.
+
+## Configuring Diacritic Similarity
+
+{{< diffcode >}}
+```javascript
+await pagefind.options({
++    ranking: {
++        diacriticSimilarity: 0.8 // default value
++    }
+});
+```
+{{< /diffcode >}}
+
+`diacriticSimilarity` controls how much boost is applied when the diacritics (accents such as àéö) in the search query match the indexed content exactly.
+
+When searching with diacritics normalized (the default behavior), this parameter determines the ranking bonus for exact diacritic matches:
+
+- At `1.0`, searching for "café" will boost pages containing "café" by 100% over pages containing "cafe", and vice versa.
+- The minimum value is `0.0`, which treats all diacritic variants equally.
+
+This parameter has no effect when [`exactDiacritics`](/docs/search-config/#exact-diacritics) is set to `true`, as non-matching diacritic variants will not appear in results at all.

--- a/docs/content/docs/search-config.md
+++ b/docs/content/docs/search-config.md
@@ -79,6 +79,22 @@ If set, Pagefind will add the search term as a query parameter under the same na
 
 If using the [Pagefind highlight script](/docs/highlighting/), make sure this is configured to match.
 
+### Exact Diacritics
+
+```json
+{
+    "exactDiacritics": true
+}
+```
+
+Defaults to `false`. When set to `true`, diacritics (accents such as àéö) are treated as fully distinct characters.
+
+By default, Pagefind normalizes diacritics so that searching for "cafe" will match pages containing "café" and vice versa. When diacritics are normalized, exact matches are still preferred via the [`ranking.diacriticSimilarity`](/docs/ranking/#configuring-diacritic-similarity) parameter.
+
+When `exactDiacritics` is set to `true`:
+- Searching for "café" will only match pages containing "café"
+- Searching for "cafe" will only match pages containing "cafe"
+
 ### Ranking
 
 See [customize ranking](/docs/ranking/)

--- a/pagefind/Cargo.toml
+++ b/pagefind/Cargo.toml
@@ -55,6 +55,7 @@ charabia = { version = "0.9.3", optional = true, default-features = false, featu
     "thai",
 ] }
 unicode-segmentation = "1.10.1"
+unicode-normalization = "0.1"
 emojis = "0.7.2"
 hashbrown = { version = "0.13.1", features = ["serde"] }
 either = "1.9.0"

--- a/pagefind/integration_tests/diacritics/pagefind-exact-diacritics-excludes-non-matching-variants.toolproof.yml
+++ b/pagefind/integration_tests/diacritics/pagefind-exact-diacritics-excludes-non-matching-variants.toolproof.yml
@@ -1,0 +1,34 @@
+name: Diacritics Tests > Pagefind exact diacritics excludes non-matching variants
+steps:
+  - step: I have the environment variable "PAGEFIND_SITE" set to "public"
+  - step: I have a "public/french/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html
+      lang="en"><head></head><body><h1>Visit our café in Paris</h1></body></html>
+  - step: I have a "public/english/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html
+      lang="en"><head></head><body><h1>Visit our cafe in London</h1></body></html>
+  - macro: I run Pagefind
+  - step: stdout should contain "Running Pagefind"
+  - step: The file "public/pagefind/pagefind.js" should not be empty
+  - step: I serve the directory "public"
+  - step: In my browser, I load "/french/"
+  - step: In my browser, the result of {js} should be exactly {expected}
+    js: |-
+      let pagefind = await import("/pagefind/pagefind.js");
+      await pagefind.options({ exactDiacritics: true });
+      let search = await pagefind.search("café");
+      let pages = await Promise.all(search.results.map(r => r.data()));
+      return pages.map(p => p.url);
+    expected:
+      - /french/
+  - step: In my browser, the result of {js} should be exactly {expected}
+    js: |-
+      let pagefind = await import("/pagefind/pagefind.js");
+      await pagefind.options({ exactDiacritics: true });
+      let search = await pagefind.search("cafe");
+      let pages = await Promise.all(search.results.map(r => r.data()));
+      return pages.map(p => p.url);
+    expected:
+      - /english/

--- a/pagefind/integration_tests/diacritics/pagefind-finds-both-accented-and-unaccented-content.toolproof.yml
+++ b/pagefind/integration_tests/diacritics/pagefind-finds-both-accented-and-unaccented-content.toolproof.yml
@@ -1,0 +1,22 @@
+name: Diacritics Tests > Pagefind finds both accented and unaccented content
+steps:
+  - step: I have the environment variable "PAGEFIND_SITE" set to "public"
+  - step: I have a "public/french/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html
+      lang="en"><head></head><body><h1>Visit our café in Paris</h1></body></html>
+  - step: I have a "public/english/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html
+      lang="en"><head></head><body><h1>Visit our cafe in London</h1></body></html>
+  - macro: I run Pagefind
+  - step: stdout should contain "Running Pagefind"
+  - step: The file "public/pagefind/pagefind.js" should not be empty
+  - step: I serve the directory "public"
+  - step: In my browser, I load "/french/"
+  - step: In my browser, the result of {js} should be exactly {expected}
+    js: |-
+      let pagefind = await import("/pagefind/pagefind.js");
+      let search = await pagefind.search("cafe");
+      return search.results.length;
+    expected: 2

--- a/pagefind/integration_tests/diacritics/pagefind-handles-arabic-diacritics.toolproof.yml
+++ b/pagefind/integration_tests/diacritics/pagefind-handles-arabic-diacritics.toolproof.yml
@@ -1,0 +1,30 @@
+name: Diacritics Tests > Pagefind handles Arabic diacritics (tashkeel)
+steps:
+  - step: I have the environment variable "PAGEFIND_SITE" set to "public"
+  - step: I have a "public/arabic-vocalized/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html dir="rtl"
+      lang="ar"><head></head><body><h1>كِتَابٌ</h1></body></html>
+  - step: I have a "public/arabic-plain/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html dir="rtl"
+      lang="ar"><head></head><body><h1>كتاب</h1></body></html>
+  - macro: I run Pagefind
+  - step: stdout should contain "Running Pagefind"
+  - step: The file "public/pagefind/pagefind.js" should not be empty
+  - step: I serve the directory "public"
+  - step: In my browser, I load "/arabic-vocalized/"
+  # Search without diacritics should find both pages
+  - step: In my browser, the result of {js} should be exactly {expected}
+    js: |-
+      let pagefind = await import("/pagefind/pagefind.js");
+      let search = await pagefind.search("كتاب");
+      return search.results.length;
+    expected: 2
+  # Search with diacritics should also find both pages
+  - step: In my browser, the result of {js} should be exactly {expected}
+    js: |-
+      let pagefind = await import("/pagefind/pagefind.js");
+      let search = await pagefind.search("كِتَابٌ");
+      return search.results.length;
+    expected: 2

--- a/pagefind/integration_tests/diacritics/pagefind-handles-nfd-decomposed-diacritics.toolproof.yml
+++ b/pagefind/integration_tests/diacritics/pagefind-handles-nfd-decomposed-diacritics.toolproof.yml
@@ -1,0 +1,56 @@
+name: Diacritics Tests > Pagefind handles NFD decomposed diacritics
+steps:
+  - step: I have the environment variable "PAGEFIND_SITE" set to "public"
+  # Vietnamese text with combining characters
+  - step: I have a "public/viet1/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html
+      lang="vi"><head></head><body><h1>Việt Nam</h1></body></html>
+  # Different diacritics on the same base word
+  - step: I have a "public/viet2/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html
+      lang="vi"><head></head><body><h1>Viët is a test</h1></body></html>
+  # Control page - starts with "vi" but shouldn't match "viet"
+  # (unless query is pared back)
+  - step: I have a "public/control/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html
+      lang="en"><head></head><body><h1>Watch a video</h1></body></html>
+  - macro: I run Pagefind
+  - step: stdout should contain "Running Pagefind"
+  - step: The file "public/pagefind/pagefind.js" should not be empty
+  - step: I serve the directory "public"
+  - step: In my browser, I load "/viet1/"
+  # Forms of "viet" should match both Vietnamese pages but NOT video
+  - step: In my browser, the result of {js} should be exactly {expected}
+    js: |-
+      let pagefind = await import("/pagefind/pagefind.js");
+      let search = await pagefind.search("viet");
+      return search.results.length;
+    expected: 2
+  - step: In my browser, the result of {js} should be exactly {expected}
+    js: |-
+      let pagefind = await import("/pagefind/pagefind.js");
+      let search = await pagefind.search("việt");
+      return search.results.length;
+    expected: 2
+  # Now with exact diacritics - each form should match only its own page
+  - step: In my browser, the result of {js} should be exactly {expected}
+    js: |-
+      let pagefind = await import("/pagefind/pagefind.js");
+      await pagefind.options({ exactDiacritics: true });
+      let search = await pagefind.search("việt");
+      let pages = await Promise.all(search.results.map(r => r.data()));
+      return pages.map(p => p.url);
+    expected:
+      - /viet1/
+  - step: In my browser, the result of {js} should be exactly {expected}
+    js: |-
+      let pagefind = await import("/pagefind/pagefind.js");
+      await pagefind.options({ exactDiacritics: true });
+      let search = await pagefind.search("viët");
+      let pages = await Promise.all(search.results.map(r => r.data()));
+      return pages.map(p => p.url);
+    expected:
+      - /viet2/

--- a/pagefind/integration_tests/diacritics/pagefind-handles-non-latin-diacritics.toolproof.yml
+++ b/pagefind/integration_tests/diacritics/pagefind-handles-non-latin-diacritics.toolproof.yml
@@ -1,0 +1,54 @@
+name: Diacritics Tests > Pagefind handles non-Latin diacritics and combining characters
+steps:
+  - step: I have the environment variable "PAGEFIND_SITE" set to "public"
+  - step: I have a "public/vietnamese/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html
+      lang="vi"><head></head><body><h1>Chào mừng đến Việt Nam</h1></body></html>
+  - step: I have a "public/german/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html
+      lang="de"><head></head><body><h1>München is a German city</h1></body></html>
+  - step: I have a "public/swedish/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html
+      lang="sv"><head></head><body><h1>Välkommen till Malmö</h1></body></html>
+  - macro: I run Pagefind
+  - step: stdout should contain "Running Pagefind"
+  - step: The file "public/pagefind/pagefind.js" should not be empty
+  - step: I serve the directory "public"
+  - step: In my browser, I load "/vietnamese/"
+  - step: In my browser, the result of {js} should be exactly {expected}
+    js: |-
+      let pagefind = await import("/pagefind/pagefind.js");
+      let search = await pagefind.search("viet");
+      let pages = await Promise.all(search.results.map(r => r.data()));
+      return pages.map(p => p.url);
+    expected:
+      - /vietnamese/
+  - step: In my browser, the result of {js} should be exactly {expected}
+    js: |-
+      let pagefind = await import("/pagefind/pagefind.js");
+      let search = await pagefind.search("mung");
+      let pages = await Promise.all(search.results.map(r => r.data()));
+      return pages.map(p => p.url);
+    expected:
+      - /vietnamese/
+  - step: In my browser, I load "/german/"
+  - step: In my browser, the result of {js} should be exactly {expected}
+    js: |-
+      let pagefind = await import("/pagefind/pagefind.js");
+      let search = await pagefind.search("munchen");
+      let pages = await Promise.all(search.results.map(r => r.data()));
+      return pages.map(p => p.url);
+    expected:
+      - /german/
+  - step: In my browser, I load "/swedish/"
+  - step: In my browser, the result of {js} should be exactly {expected}
+    js: |-
+      let pagefind = await import("/pagefind/pagefind.js");
+      let search = await pagefind.search("malmo");
+      let pages = await Promise.all(search.results.map(r => r.data()));
+      return pages.map(p => p.url);
+    expected:
+      - /swedish/

--- a/pagefind/integration_tests/diacritics/pagefind-matches-accented-content-with-unaccented-query.toolproof.yml
+++ b/pagefind/integration_tests/diacritics/pagefind-matches-accented-content-with-unaccented-query.toolproof.yml
@@ -1,0 +1,20 @@
+name: Diacritics Tests > Pagefind matches accented content with unaccented query
+steps:
+  - step: I have the environment variable "PAGEFIND_SITE" set to "public"
+  - step: I have a "public/cafe/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html
+      lang="en"><head></head><body><h1>Visit our café for great coffee</h1></body></html>
+  - macro: I run Pagefind
+  - step: stdout should contain "Running Pagefind"
+  - step: The file "public/pagefind/pagefind.js" should not be empty
+  - step: I serve the directory "public"
+  - step: In my browser, I load "/cafe/"
+  - step: In my browser, the result of {js} should be exactly {expected}
+    js: |-
+      let pagefind = await import("/pagefind/pagefind.js");
+      let search = await pagefind.search("cafe");
+      let pages = await Promise.all(search.results.map(r => r.data()));
+      return pages.map(p => p.url);
+    expected:
+      - /cafe/

--- a/pagefind/integration_tests/diacritics/pagefind-matches-unaccented-content-with-accented-query.toolproof.yml
+++ b/pagefind/integration_tests/diacritics/pagefind-matches-unaccented-content-with-accented-query.toolproof.yml
@@ -1,0 +1,20 @@
+name: Diacritics Tests > Pagefind matches unaccented content with accented query
+steps:
+  - step: I have the environment variable "PAGEFIND_SITE" set to "public"
+  - step: I have a "public/coffee/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html
+      lang="en"><head></head><body><h1>Visit our cafe for great coffee</h1></body></html>
+  - macro: I run Pagefind
+  - step: stdout should contain "Running Pagefind"
+  - step: The file "public/pagefind/pagefind.js" should not be empty
+  - step: I serve the directory "public"
+  - step: In my browser, I load "/coffee/"
+  - step: In my browser, the result of {js} should be exactly {expected}
+    js: |-
+      let pagefind = await import("/pagefind/pagefind.js");
+      let search = await pagefind.search("café");
+      let pages = await Promise.all(search.results.map(r => r.data()));
+      return pages.map(p => p.url);
+    expected:
+      - /coffee/

--- a/pagefind/integration_tests/scoring_custom/diacritic-similarity-ranking-can-be-configured.toolproof.yml
+++ b/pagefind/integration_tests/scoring_custom/diacritic-similarity-ranking-can-be-configured.toolproof.yml
@@ -1,0 +1,36 @@
+name: Result Scoring > Diacritic similarity ranking can be configured
+steps:
+  - ref: ./background.toolproof.yml
+  - step: I have a "public/accented/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html lang="en"><head></head><body><p>Visit our café in
+      Paris</p></body></html>
+  - step: I have a "public/unaccented/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html lang="en"><head></head><body><p>Visit our cafe in
+      London, the best cafe around</p></body></html>
+  - macro: I run Pagefind
+  - step: stdout should contain "Running Pagefind"
+  - step: I serve the directory "public"
+  - step: In my browser, I load "/"
+  # Default: diacritic bonus overrides the extra cafe frequency
+  - step: In my browser, the result of {js} should be exactly {expected}
+    js: |-
+      let pagefind = await import("/pagefind/pagefind.js");
+      let search = await pagefind.search("café");
+      let pages = await Promise.all(search.results.map(r => r.data()));
+      return pages.map(p => p.url);
+    expected:
+      - /accented/
+      - /unaccented/
+  # diacriticSimilarity zeroed out restores us to frequency winning
+  - step: In my browser, the result of {js} should be exactly {expected}
+    js: |-
+      let pagefind = await import("/pagefind/pagefind.js");
+      await pagefind.options({ ranking: { diacriticSimilarity: 0.0 } });
+      let search = await pagefind.search("café");
+      let pages = await Promise.all(search.results.map(r => r.data()));
+      return pages.map(p => p.url);
+    expected:
+      - /unaccented/
+      - /accented/

--- a/pagefind/integration_tests/scoring_defaults/exact-diacritic-matches-rank-higher.toolproof.yml
+++ b/pagefind/integration_tests/scoring_defaults/exact-diacritic-matches-rank-higher.toolproof.yml
@@ -1,0 +1,33 @@
+name: Result Scoring > Exact diacritic matches rank higher
+steps:
+  - ref: ./background.toolproof.yml
+  - step: I have a "public/accented/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html lang="en"><head></head><body><p>Visit our café in
+      Paris</p></body></html>
+  - step: I have a "public/unaccented/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html lang="en"><head></head><body><p>Visit our cafe in
+      London</p></body></html>
+  - macro: I run Pagefind
+  - step: stdout should contain "Running Pagefind"
+  - step: I serve the directory "public"
+  - step: In my browser, I load "/"
+  - step: In my browser, the result of {js} should be exactly {expected}
+    js: |-
+      let pagefind = await import("/pagefind/pagefind.js");
+      let search = await pagefind.search("café");
+      let pages = await Promise.all(search.results.map(r => r.data()));
+      return pages.map(p => p.url);
+    expected:
+      - /accented/
+      - /unaccented/
+  - step: In my browser, the result of {js} should be exactly {expected}
+    js: |-
+      let pagefind = await import("/pagefind/pagefind.js");
+      let search = await pagefind.search("cafe");
+      let pages = await Promise.all(search.results.map(r => r.data()));
+      return pages.map(p => p.url);
+    expected:
+      - /unaccented/
+      - /accented/

--- a/pagefind/src/index/index_words.rs
+++ b/pagefind/src/index/index_words.rs
@@ -16,6 +16,17 @@ pub struct PackedWord {
     pub word: String,
     #[n(1)]
     pub pages: Vec<PackedPage>,
+    #[n(2)]
+    pub additional_variants: Vec<PackedVariant>,
+}
+
+/// A variant of a word with different diacritics (e.g., "café" vs "cafe")
+#[derive(Encode, Clone, Debug)]
+pub struct PackedVariant {
+    #[n(0)]
+    pub form: String,
+    #[n(1)]
+    pub pages: Vec<PackedPage>,
 }
 
 /// A set of locations on a given page

--- a/pagefind_web_js/types/index.d.ts
+++ b/pagefind_web_js/types/index.d.ts
@@ -22,7 +22,7 @@ declare global {
      */
     mergeFilter?: Object;
     /**
-     * If set, will ass the search term as a query parameter under this key, for use with Pagefind's highlighting script.
+     * If set, will add the search term as a query parameter under this key, for use with Pagefind's highlighting script.
      */
     highlightParam?: string;
     language?: string;
@@ -37,6 +37,13 @@ declare global {
      */
     ranking?: PagefindRankingWeights;
     /**
+     * If set, diacritics are treated as fully distinct words.
+     * This means searching for "café" will only match pages containing "café", not "cafe".
+     * When false (default), diacritics are normalized and all variants match,
+     * with ranking.diacriticSimilarity applied to favor close matches.
+     */
+    exactDiacritics?: boolean;
+    /**
      * Force Pagefind to run on the main thread instead of using a web worker.
      *
      * By default, Pagefind will use a web worker for search operations when available,
@@ -47,33 +54,40 @@ declare global {
 
   type PagefindRankingWeights = {
     /**
-            Controls page ranking based on similarity of terms to the search query (in length).
-            Increasing this number means pages rank higher when they contain words very close to the query,
-            e.g. if searching for `part` then `party` will boost a page higher than one containing `partition`.
-            Minimum value is 0.0, where `party` and `partition` would be viewed equally.
-        */
+      Controls page ranking based on similarity of terms to the search query (in length).
+      Increasing this number means pages rank higher when they contain words very close to the query,
+      e.g. if searching for `part` then `party` will boost a page higher than one containing `partition`.
+      Minimum value is 0.0, where `party` and `partition` would be viewed equally.
+    */
     termSimilarity?: Number;
     /**
-            Controls how much effect the average page length has on ranking.
-            Maximum value is 1.0, where ranking will strongly favour pages that are shorter than the average page on the site.
-            Minimum value is 0.0, where ranking will exclusively look at term frequency, regardless of how long a document is.
-        */
+      Controls how much effect the average page length has on ranking.
+      Maximum value is 1.0, where ranking will strongly favour pages that are shorter than the average page on the site.
+      Minimum value is 0.0, where ranking will exclusively look at term frequency, regardless of how long a document is.
+    */
     pageLength?: Number;
     /**
-            Controls how quickly a term saturates on the page and reduces impact on the ranking.
-            Maximum value is 2.0, where pages will take a long time to saturate, and pages with very high term frequencies will take over.
-            As this number trends to 0, it does not take many terms to saturate and allow other paramaters to influence the ranking.
-            Minimum value is 0.0, where terms will saturate immediately and results will not distinguish between one term and many.
-        */
+      Controls how quickly a term saturates on the page and reduces impact on the ranking.
+      Maximum value is 2.0, where pages will take a long time to saturate, and pages with very high term frequencies will take over.
+      As this number trends to 0, it does not take many terms to saturate and allow other paramaters to influence the ranking.
+      Minimum value is 0.0, where terms will saturate immediately and results will not distinguish between one term and many.
+    */
     termSaturation?: Number;
     /**
-            Controls how much ranking uses term frequency versus raw term count.
-            Maximum value is 1.0, where term frequency fully applies and is the main ranking factor.
-            Minimum value is 0.0, where term frequency does not apply, and pages are ranked based on the raw sum of words and weights.
-            Values between 0.0 and 1.0 will interpolate between the two ranking methods.
-            Reducing this number is a good way to boost longer documents in your search results, as they no longer get penalized for having a low term frequency.
-         */
+      Controls how much ranking uses term frequency versus raw term count.
+      Maximum value is 1.0, where term frequency fully applies and is the main ranking factor.
+      Minimum value is 0.0, where term frequency does not apply, and pages are ranked based on the raw sum of words and weights.
+      Values between 0.0 and 1.0 will interpolate between the two ranking methods.
+      Reducing this number is a good way to boost longer documents in your search results, as they no longer get penalized for having a low term frequency.
+      */
     termFrequency?: Number;
+    /**
+      Controls how much boost is applied when the search query diacritics match the indexed word exactly.
+      At 1.0, searching for "café" will boost pages containing "café" by 100% over pages containing "cafe".
+      At 0.0, no boost is applied and all diacritic variants are treated equally.
+      Must be >= 0
+    */
+    diacriticSimilarity?: Number;
   };
 
   /** Options that can be passed to pagefind.search() */

--- a/wrappers/node/package-lock.json
+++ b/wrappers/node/package-lock.json
@@ -17,6 +17,7 @@
       "optionalDependencies": {
         "@pagefind/darwin-arm64": "0.0.0",
         "@pagefind/darwin-x64": "0.0.0",
+        "@pagefind/freebsd-x64": "0.0.0",
         "@pagefind/linux-arm64": "0.0.0",
         "@pagefind/linux-x64": "0.0.0",
         "@pagefind/windows-x64": "0.0.0"


### PR DESCRIPTION
Diacritic characters are now indexed in their normalized form, so é is indexed as e for retrieval. Page and word locations are still tied to the original word, just nested within the normalized index.

Previously, a <sup>rough</sup> mental model of the index would be:
```
"resume" → { pages: [ ... ] }
"résumé" → { pages: [ ... ] }
"resumé" → { pages: [ ... ] }
```

and is now <sup>also roughly</sup>:
```
"resume" → {
  pages:    [ ... ],
  variants: [
    "résumé" → [ ... ],
    "resumé" → [ ... ],
  ]
}
```

With this, searches for `résumé` in any form resolve via the normalized `resume`, but ranking information for each form is retained. This means that the new default behaviour for Pagefind is that searching for `café` returns results for both `cafe` and `café`, but the `café` results are given a ranking boost due to the matching diacritic.

This new ranking boost can be configured with the `diacriticSimilarity` ranking weight, and this cross-word matching can be entirely disabled at search time with the `exactDiacritics` search option. 

This also handles non-latin scripts, such as Arabic tashkeel and Vietnamese tones.

Addresses:

- #538
- #980
- #724