### PR TITLE
feat: key press of slash focuses search bar

### DIFF
--- a/docs/content/docs/ui.md
+++ b/docs/content/docs/ui.md
@@ -196,6 +196,35 @@ new PagefindUI({
 
 Enabling autofocus automatically directs attention to the search input field for enhanced user convenience, particularly beneficial when the UI is loaded within a modal dialog. However, exercise caution, as using autofocus indiscriminately may pose potential accessibility challenges.
 
+### Focus on slash
+
+{{< diffcode >}}
+```javascript
+new PagefindUI({
+    element: "#search",
++    focusOnSlash: true
+});
+```
+{{< /diffcode >}}
+
+When enabled, pressing the `/` key anywhere on the page will focus the search input. This is a common pattern used by many websites (e.g., GitHub, YouTube) to provide quick keyboard access to search. Defaults to `false`.
+
+The feature will not trigger if the user is already typing in another input field, textarea, or contenteditable element.
+
+Consider combining this with a custom placeholder to hint users about the shortcut:
+
+{{< diffcode >}}
+```javascript
+new PagefindUI({
+    element: "#search",
++    focusOnSlash: true,
++    translations: {
++        placeholder: "Press / to search"
++    }
+});
+```
+{{< /diffcode >}}
+
 ### Sort
 
 {{< diffcode >}}

--- a/pagefind/integration_tests/ui/ui_slash_focus/background.toolproof.yml
+++ b/pagefind/integration_tests/ui/ui_slash_focus/background.toolproof.yml
@@ -1,0 +1,4 @@
+name: ui/ui_slash_focus > Slash Focus > Background
+type: reference
+steps:
+  - step: I have the environment variable "PAGEFIND_SITE" set to "public"

--- a/pagefind/integration_tests/ui/ui_slash_focus/pagefind-ui-does-not-focus-on-slash-by-default.toolproof.yml
+++ b/pagefind/integration_tests/ui/ui_slash_focus/pagefind-ui-does-not-focus-on-slash-by-default.toolproof.yml
@@ -1,0 +1,42 @@
+name: Slash Focus > Pagefind UI does not focus on slash keypress by default
+steps:
+  - ref: ./background.toolproof.yml
+  - step: I have a "public/index.html" file with the content {html}
+    html: |-
+      <!DOCTYPE html><html lang="en"><head></head><body><h1>Search</h1>
+      <div id="search"></div>
+      <script src="/pagefind/pagefind-ui.js"></script>
+
+      <script>
+          window.pui = new PagefindUI({
+              element: "#search"
+          });
+      </script></body></html>
+  - step: I have a "public/cat/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html
+      lang="en"><head></head><body><h1>world</h1></body></html>
+  - macro: I run Pagefind
+  - step: stdout should contain "Running Pagefind"
+  - step: The file "public/pagefind/pagefind.js" should not be empty
+  - step: I serve the directory "public"
+  - step: In my browser, I load "/"
+  - step: In my browser, I evaluate {js}
+    js: |-
+      // First ensure the input is NOT focused
+      let input = await toolproof.querySelector(".pagefind-ui__search-input");
+      if (document.activeElement === input) {
+          throw new Error("Input should not be focused initially");
+      }
+
+      // Simulate pressing the '/' key on the document
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: '/' }));
+
+      // Wait a moment
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      // Check that the input is still NOT focused (since focusOnSlash is not enabled)
+      if (document.activeElement === input) {
+          throw new Error("Input should NOT be focused when focusOnSlash is not enabled");
+      }
+  - step: In my browser, the console should be empty

--- a/pagefind/integration_tests/ui/ui_slash_focus/pagefind-ui-focuses-on-slash-keypress.toolproof.yml
+++ b/pagefind/integration_tests/ui/ui_slash_focus/pagefind-ui-focuses-on-slash-keypress.toolproof.yml
@@ -1,0 +1,43 @@
+name: Slash Focus > Pagefind UI focuses input on slash keypress when enabled
+steps:
+  - ref: ./background.toolproof.yml
+  - step: I have a "public/index.html" file with the content {html}
+    html: |-
+      <!DOCTYPE html><html lang="en"><head></head><body><h1>Search</h1>
+      <div id="search"></div>
+      <script src="/pagefind/pagefind-ui.js"></script>
+
+      <script>
+          window.pui = new PagefindUI({
+              element: "#search",
+              focusOnSlash: true
+          });
+      </script></body></html>
+  - step: I have a "public/cat/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html
+      lang="en"><head></head><body><h1>world</h1></body></html>
+  - macro: I run Pagefind
+  - step: stdout should contain "Running Pagefind"
+  - step: The file "public/pagefind/pagefind.js" should not be empty
+  - step: I serve the directory "public"
+  - step: In my browser, I load "/"
+  - step: In my browser, I evaluate {js}
+    js: |-
+      // First ensure the input is NOT focused
+      let input = await toolproof.querySelector(".pagefind-ui__search-input");
+      if (document.activeElement === input) {
+          throw new Error("Input should not be focused initially");
+      }
+
+      // Simulate pressing the '/' key on the document
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: '/' }));
+
+      // Wait a moment for the focus to happen
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      // Check if the input is now focused
+      if (document.activeElement !== input) {
+          throw new Error("Input should be focused after pressing '/'");
+      }
+  - step: In my browser, the console should be empty

--- a/pagefind/integration_tests/ui/ui_slash_focus/pagefind-ui-slash-focus-placeholder.toolproof.yml
+++ b/pagefind/integration_tests/ui/ui_slash_focus/pagefind-ui-slash-focus-placeholder.toolproof.yml
@@ -1,0 +1,34 @@
+name: Slash Focus > Pagefind UI shows custom placeholder when focusOnSlash is enabled
+steps:
+  - ref: ./background.toolproof.yml
+  - step: I have a "public/index.html" file with the content {html}
+    html: |-
+      <!DOCTYPE html><html lang="en"><head></head><body><h1>Search</h1>
+      <div id="search"></div>
+      <script src="/pagefind/pagefind-ui.js"></script>
+
+      <script>
+          window.pui = new PagefindUI({
+              element: "#search",
+              focusOnSlash: true,
+              translations: {
+                  placeholder: "Press / to search"
+              }
+          });
+      </script></body></html>
+  - step: I have a "public/cat/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html
+      lang="en"><head></head><body><h1>world</h1></body></html>
+  - macro: I run Pagefind
+  - step: stdout should contain "Running Pagefind"
+  - step: The file "public/pagefind/pagefind.js" should not be empty
+  - step: I serve the directory "public"
+  - step: In my browser, I load "/"
+  - step: In my browser, I evaluate {js}
+    js: |-
+      let input = await toolproof.querySelector(".pagefind-ui__search-input");
+      if (input.getAttribute("placeholder") !== "Press / to search") {
+          throw new Error("Placeholder should be 'Press / to search' but was: " + input.getAttribute("placeholder"));
+      }
+  - step: In my browser, the console should be empty

--- a/pagefind_ui/default/svelte/ui.svelte
+++ b/pagefind_ui/default/svelte/ui.svelte
@@ -36,6 +36,7 @@
   export let trigger_search_term = "";
   export let translations = {};
   export let autofocus = false;
+  export let focus_on_slash = false;
   export let sort = null;
   export let selected_filters = {};
 
@@ -65,6 +66,24 @@
     return overrides[key] ?? auto[key] ?? "";
   };
 
+  const handleSlashKeydown = (e) => {
+    // Only handle if focusOnSlash is enabled
+    if (!focus_on_slash) return;
+
+    // Don't focus if user is typing in an input, textarea, or contenteditable
+    const activeEl = document.activeElement;
+    const isTyping =
+      activeEl &&
+      (activeEl.tagName === "INPUT" ||
+        activeEl.tagName === "TEXTAREA" ||
+        activeEl.isContentEditable);
+
+    if (e.key === "/" && !isTyping) {
+      e.preventDefault();
+      input_el?.focus();
+    }
+  };
+
   onMount(() => {
     let lang =
       document?.querySelector?.("html")?.getAttribute?.("lang") || "en";
@@ -77,11 +96,21 @@
       availableTranslations[`${parsedLang.language}-${parsedLang.region}`] ||
       availableTranslations[`${parsedLang.language}`] ||
       availableTranslations["en"];
+
+    // Set up slash key listener if enabled
+    if (focus_on_slash) {
+      document.addEventListener("keydown", handleSlashKeydown);
+    }
   });
 
   onDestroy(() => {
     pagefind?.destroy?.();
     pagefind = null;
+
+    // Clean up slash key listener
+    if (focus_on_slash) {
+      document.removeEventListener("keydown", handleSlashKeydown);
+    }
   });
 
   $: debouncedSearch(val, selected_filters);

--- a/pagefind_ui/default/ui-core.js
+++ b/pagefind_ui/default/ui-core.js
@@ -31,6 +31,7 @@ export class PagefindUI {
     let mergeIndex = opts.mergeIndex ?? [];
     let translations = opts.translations ?? [];
     let autofocus = opts.autofocus ?? false;
+    let focusOnSlash = opts.focusOnSlash ?? false;
     let sort = opts.sort ?? null;
 
     // Remove the UI-specific config before passing it along to the Pagefind backend
@@ -49,6 +50,7 @@ export class PagefindUI {
     delete opts["mergeIndex"];
     delete opts["translations"];
     delete opts["autofocus"];
+    delete opts["focusOnSlash"];
     delete opts["sort"];
 
     const dom =
@@ -73,6 +75,7 @@ export class PagefindUI {
           merge_index: mergeIndex,
           translations,
           autofocus,
+          focus_on_slash: focusOnSlash,
           sort,
           pagefind_options: opts,
         },


### PR DESCRIPTION
First time caller, hope I got it right.

Having used search on websites and loving the keyboard focus, and recognizing that `autofocus` can solve the issue, yet introduces accessibility concerns, I thought that adding the ability to implement to opt in to a method for surfacing the feature.

Happy to take some feedback, this isn't the most familiar code for me yet.