### PR TITLE
Add scoped instances to initialize properly separate configurations

### DIFF
--- a/pagefind/integration_tests/web_components/multiple-instances-config-isolation.toolproof.yml
+++ b/pagefind/integration_tests/web_components/multiple-instances-config-isolation.toolproof.yml
@@ -1,0 +1,60 @@
+name: Web Components Tests > Config does not bleed between instances
+steps:
+  - step: I have the environment variable "PAGEFIND_SITE" set to "public"
+  - step: I have a "public/index.html" file with the content {html}
+    html: |-
+      <!DOCTYPE html><html lang="en"><head></head><body>
+      <h1>Config Isolation Test</h1>
+      <script type="module">
+        // Test createInstance() isolation directly via the JS API.
+        // Two instances over the same index with different excerptLength values
+        // should produce different excerpt strings for the same result.
+        import * as pagefind from "/pagefind/pagefind.js";
+
+        const instanceA = pagefind.createInstance({ excerptLength: 5 });
+        const instanceB = pagefind.createInstance({ excerptLength: 30 });
+
+        const searchA = await instanceA.search("page");
+        const searchB = await instanceB.search("page");
+
+        const dataA = await searchA.results[0].data();
+        const dataB = await searchB.results[0].data();
+
+        // Store results on window for toolproof to read
+        window.__testResults = {
+          excerptA: dataA.excerpt,
+          excerptB: dataB.excerpt,
+          wordCountA: dataA.excerpt.replace(/<[^>]*>/g, '').split(/\s+/).filter(Boolean).length,
+          wordCountB: dataB.excerpt.replace(/<[^>]*>/g, '').split(/\s+/).filter(Boolean).length,
+        };
+      </script>
+      </body></html>
+  - step: I have a "public/long/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html lang="en"><head></head><body><h1>Long
+      Page</h1><p>This is a page with many words so that different excerpt
+      lengths will produce visibly different excerpts. The content here is
+      deliberately long enough that an excerpt of five words will be much
+      shorter than an excerpt of thirty words. We add extra filler text to
+      make absolutely sure the difference is clear and testable.</p></body></html>
+  - macro: I run Pagefind
+  - step: stdout should contain "Running Pagefind"
+  - step: The file "public/pagefind/pagefind.js" should not be empty
+  - step: I serve the directory "public"
+  - step: In my browser, I load "/"
+  - step: In my browser, I evaluate {js}
+    js: |-
+      await toolproof.waitFor(() => window.__testResults, 10000);
+      let r = window.__testResults;
+
+      // Instance A (excerptLength: 5) should have ~5 words
+      toolproof.assert(r.wordCountA <= 6,
+        `Instance A excerpt should have ~5 words, got ${r.wordCountA}: "${r.excerptA}"`);
+
+      // Instance B (excerptLength: 30) should have ~30 words
+      toolproof.assert(r.wordCountB > 15,
+        `Instance B excerpt should have many more words, got ${r.wordCountB}: "${r.excerptB}"`);
+
+      // Instance B must have more words than Instance A
+      toolproof.assert(r.wordCountB > r.wordCountA,
+        `Excerpts should differ: A=${r.wordCountA} words, B=${r.wordCountB} words. Config may be bleeding between instances.`);

--- a/pagefind_ui/component/core/instance.ts
+++ b/pagefind_ui/component/core/instance.ts
@@ -612,9 +612,9 @@ export class Instance {
   private async __doLoad__(): Promise<void> {
     if (this.__pagefind__) return;
 
-    let imported_pagefind: PagefindAPI;
+    let pagefindModule: any;
     try {
-      imported_pagefind = await import(
+      pagefindModule = await import(
         /* @vite-ignore */
         `${this.options.bundlePath}pagefind.js`
       );
@@ -655,7 +655,12 @@ export class Instance {
       return;
     }
 
-    await imported_pagefind.options(this.pagefindOptions || {});
+    // Each component instance gets its own isolated Pagefind backend,
+    // preventing config from bleeding between instances on the same page.
+    const imported_pagefind = pagefindModule.createInstance(
+      this.pagefindOptions || {},
+    ) as PagefindAPI;
+
     for (const index of this.options.mergeIndex) {
       if (!index.bundlePath) {
         throw new Error("mergeIndex requires a bundlePath parameter");

--- a/pagefind_web_js/lib/pagefind_worker.ts
+++ b/pagefind_web_js/lib/pagefind_worker.ts
@@ -2,6 +2,7 @@ import { Pagefind } from "./coupled_search.js";
 
 interface WorkerMessage {
   id: string;
+  instanceId?: string;
   method: string;
   args: any[];
 }
@@ -13,51 +14,68 @@ interface WorkerResponse {
 }
 
 let dataCallbacks: Map<string, any> = new Map();
-let pagefindInstance: Pagefind | null = null;
+let instanceDataIds: Map<string, Set<string>> = new Map();
+let instances: Map<string, Pagefind> = new Map();
+
+// Defensive fallback if a message arrives without an instanceId
+const DEFAULT_INSTANCE = "default";
+
+const getInstance = (instanceId: string): Pagefind => {
+  const instance = instances.get(instanceId);
+  if (!instance) {
+    throw new Error(`Pagefind instance "${instanceId}" not initialized`);
+  }
+  return instance;
+};
+
+const registerDataCallback = (
+  instanceId: string,
+  dataId: string,
+  dataFn: any,
+): void => {
+  dataCallbacks.set(dataId, { getData: dataFn });
+  if (!instanceDataIds.has(instanceId)) {
+    instanceDataIds.set(instanceId, new Set());
+  }
+  instanceDataIds.get(instanceId)!.add(dataId);
+};
 
 const handleMessage = async (
   message: WorkerMessage,
 ): Promise<WorkerResponse> => {
   const { id, method, args } = message;
+  const instanceId = message.instanceId ?? DEFAULT_INSTANCE;
 
   try {
     switch (method) {
       case "init": {
         const [options] = args;
-        pagefindInstance = new Pagefind(options);
+        instances.set(instanceId, new Pagefind(options));
         return { id, result: true };
       }
 
       case "options": {
-        if (!pagefindInstance) {
-          throw new Error("Pagefind not initialized");
-        }
+        const pagefindInstance = getInstance(instanceId);
         const [options] = args;
         await pagefindInstance.options(options);
         return { id, result: true };
       }
 
       case "enterPlaygroundMode": {
-        if (!pagefindInstance) {
-          throw new Error("Pagefind not initialized");
-        }
+        const pagefindInstance = getInstance(instanceId);
         await pagefindInstance.enterPlaygroundMode();
         return { id, result: true };
       }
 
       case "mergeIndex": {
-        if (!pagefindInstance) {
-          throw new Error("Pagefind not initialized");
-        }
+        const pagefindInstance = getInstance(instanceId);
         const [indexPath, options] = args;
         await pagefindInstance.mergeIndex(indexPath, options);
         return { id, result: true };
       }
 
       case "search": {
-        if (!pagefindInstance) {
-          throw new Error("Pagefind not initialized");
-        }
+        const pagefindInstance = getInstance(instanceId);
         const [term, options] = args;
         const results = await pagefindInstance.search(term, options);
 
@@ -68,9 +86,7 @@ const handleMessage = async (
             const dataFn = result.data;
             const dataId = `data_${id}_${i}`;
 
-            dataCallbacks.set(dataId, {
-              getData: dataFn,
-            } as any);
+            registerDataCallback(instanceId, dataId, dataFn);
 
             result.data = dataId as any;
           }
@@ -84,9 +100,7 @@ const handleMessage = async (
       }
 
       case "debouncedSearch": {
-        if (!pagefindInstance) {
-          throw new Error("Pagefind not initialized");
-        }
+        const pagefindInstance = getInstance(instanceId);
         const [term, options, debounceTimeoutMs] = args;
         const results = await pagefindInstance.debouncedSearch(
           term,
@@ -101,9 +115,7 @@ const handleMessage = async (
             const dataFn = result.data;
             const dataId = `data_${id}_${i}`;
 
-            dataCallbacks.set(dataId, {
-              getData: dataFn,
-            } as any);
+            registerDataCallback(instanceId, dataId, dataFn);
 
             result.data = dataId as any;
           }
@@ -117,41 +129,45 @@ const handleMessage = async (
       }
 
       case "preload": {
-        if (!pagefindInstance) {
-          throw new Error("Pagefind not initialized");
-        }
+        const pagefindInstance = getInstance(instanceId);
         const [term, options] = args;
         await pagefindInstance.preload(term, options);
         return { id, result: true };
       }
 
       case "filters": {
-        if (!pagefindInstance) {
-          throw new Error("Pagefind not initialized");
-        }
+        const pagefindInstance = getInstance(instanceId);
         const result = await pagefindInstance.filters();
         return { id, result };
       }
 
       case "getData": {
         const [dataId] = args;
-        const instance = dataCallbacks.get(dataId);
-        if (!instance || !(instance as any).getData) {
-          throw new Error(`Data function ${dataId} not found`);
+        const callback = dataCallbacks.get(dataId);
+        if (!callback?.getData) {
+          // Instance may have been destroyed while data() was in-flight
+          return { id, result: null };
         }
-        const data = await (instance as any).getData();
+        const data = await callback.getData();
         return { id, result: data };
       }
 
       case "releaseData": {
         const [dataId] = args;
         dataCallbacks.delete(dataId);
+        instanceDataIds.get(instanceId)?.delete(dataId);
         return { id, result: true };
       }
 
       case "destroy": {
-        dataCallbacks.clear();
-        pagefindInstance = null;
+        instances.delete(instanceId);
+        const dataIds = instanceDataIds.get(instanceId);
+        if (dataIds) {
+          for (const dataId of dataIds) {
+            dataCallbacks.delete(dataId);
+          }
+          instanceDataIds.delete(instanceId);
+        }
         return { id, result: true };
       }
 

--- a/pagefind_web_js/lib/public_search_api.ts
+++ b/pagefind_web_js/lib/public_search_api.ts
@@ -3,31 +3,30 @@ import { PagefindWrapper } from "./search_wrapper.js";
 let pagefind: PagefindWrapper | undefined = undefined;
 let initial_options: PagefindIndexOptions | undefined = undefined;
 
+const deriveBasePath = (explicit?: string): string | undefined => {
+  if (explicit) return explicit;
+  if (typeof import.meta.url !== "undefined") {
+    return import.meta.url.match(
+      /^(.*\/)pagefind.js.*$/,
+    )?.[1];
+  }
+};
+
+const detectLanguage = (): string => {
+  if (typeof document !== "undefined" && document?.querySelector) {
+    return (
+      document.querySelector("html")?.getAttribute("lang") || "unknown"
+    ).toLowerCase();
+  }
+  return "unknown";
+};
+
 const init_pagefind = () => {
   if (!pagefind) {
-    let basePath = initial_options?.basePath;
-
-    // Derive basePath if not explicitly provided
-    if (!basePath && typeof import.meta.url !== "undefined") {
-      let derivedBasePath = import.meta.url.match(
-        /^(.*\/)pagefind.js.*$/,
-      )?.[1];
-      if (derivedBasePath) {
-        basePath = derivedBasePath;
-      }
-    }
-
-    let language = "unknown";
-    if (typeof document !== "undefined" && document?.querySelector) {
-      const langCode =
-        document.querySelector("html")?.getAttribute("lang") || "unknown";
-      language = langCode.toLowerCase();
-    }
-
     pagefind = new PagefindWrapper({
       ...initial_options,
-      basePath,
-      language,
+      basePath: deriveBasePath(initial_options?.basePath),
+      language: detectLanguage(),
       primary: true,
     });
   }
@@ -77,4 +76,39 @@ export const preload = async (term: string, options: PagefindSearchOptions) => {
 export const filters = async () => {
   init_pagefind();
   return await pagefind!.filters();
+};
+
+/**
+ * Creates an independent Pagefind instance with its own configuration.
+ * Use this when you need multiple search instances on the same page
+ * with different options.
+ * All instances share a single web worker and WASM module internally.
+ */
+export const createInstance = (
+  instanceOptions?: PagefindIndexOptions,
+): PagefindInstance => {
+  const wrapper = new PagefindWrapper({
+    ...instanceOptions,
+    basePath: deriveBasePath(instanceOptions?.basePath),
+    language: detectLanguage(),
+    primary: true,
+  });
+
+  return {
+    options: (opts: PagefindIndexOptions) => wrapper.options(opts),
+    init: () => wrapper.waitForInit(),
+    destroy: () => wrapper.destroy(),
+    mergeIndex: (indexPath: string, options: PagefindIndexOptions) =>
+      wrapper.mergeIndex(indexPath, options),
+    search: (term: string, options: PagefindSearchOptions = {}) =>
+      wrapper.search(term, options),
+    debouncedSearch: (
+      term: string,
+      options?: PagefindSearchOptions,
+      debounceTimeoutMs: number = 300,
+    ) => wrapper.debouncedSearch(term, options, debounceTimeoutMs),
+    preload: (term: string, options: PagefindSearchOptions = {}) =>
+      wrapper.preload(term, options),
+    filters: () => wrapper.filters(),
+  };
 };

--- a/pagefind_web_js/lib/search_wrapper.ts
+++ b/pagefind_web_js/lib/search_wrapper.ts
@@ -5,31 +5,110 @@ const hasWorkerSupport =
   typeof document !== "undefined" &&
   typeof Worker !== "undefined";
 
+// Shared worker state: one worker serves all PagefindWrapper instances.
+// Each wrapper gets a unique instanceId to namespace its messages.
+let sharedWorker: Worker | null = null;
+let sharedWorkerRefCount = 0;
+let sharedMessageHandlers: Map<
+  string,
+  { resolve: Function; reject: Function }
+> = new Map();
+
+let nextInstanceId = 0;
+const generateInstanceId = (): string => `pf_${nextInstanceId++}`;
+
+function initSharedWorker(basePath: string): boolean {
+  if (sharedWorker) return true;
+
+  try {
+    const workerUrl = `${basePath}pagefind-worker.js`;
+    sharedWorker = new Worker(workerUrl);
+
+    sharedWorker.addEventListener("error", (error) => {
+      console.warn(
+        "The Pagefind web worker encountered an error, falling back to main thread:",
+        error,
+      );
+      sharedWorker = null;
+
+      // Reject all pending messages across all instances
+      const pending = Array.from(sharedMessageHandlers.values());
+      sharedMessageHandlers.clear();
+      for (const { reject } of pending) {
+        reject(new Error("Worker failed, falling back to main thread"));
+      }
+    });
+
+    sharedWorker.addEventListener("message", (event) => {
+      const { id, result, error } = event.data;
+      const pending = sharedMessageHandlers.get(id);
+      if (pending) {
+        sharedMessageHandlers.delete(id);
+        if (error) {
+          pending.reject(new Error(error));
+        } else {
+          pending.resolve(result);
+        }
+      }
+    });
+
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+function releaseSharedWorker(): void {
+  sharedWorkerRefCount--;
+  if (sharedWorkerRefCount <= 0 && sharedWorker) {
+    sharedWorker.terminate();
+    sharedWorker = null;
+    sharedWorkerRefCount = 0;
+
+    const pending = Array.from(sharedMessageHandlers.values());
+    sharedMessageHandlers.clear();
+    for (const { reject } of pending) {
+      reject(new Error("Pagefind worker terminated"));
+    }
+  }
+}
+
+let globalMessageId = 0;
+
+function sendWorkerMessage(
+  instanceId: string,
+  method: string,
+  args: any[],
+): Promise<any> {
+  if (!sharedWorker) {
+    return Promise.reject(new Error("Worker not available"));
+  }
+
+  return new Promise((resolve, reject) => {
+    const id = `msg_${globalMessageId++}`;
+    sharedMessageHandlers.set(id, { resolve, reject });
+    sharedWorker!.postMessage({ id, instanceId, method, args });
+  });
+}
+
 export class PagefindWrapper {
-  private worker: Worker | null = null;
-  private messageId = 0;
-  private pendingMessages: Map<
-    string,
-    { resolve: Function; reject: Function }
-  > = new Map();
+  private instanceId: string;
   private fallback: Pagefind | null = null;
   private basePath: string;
   private initOptions: PagefindIndexOptions;
   private cleanup: FinalizationRegistry<string> | undefined;
   private initPromise: Promise<void> | null = null;
   private initialized = false;
+  private useWorker = false;
 
   private initCleanup() {
     if (typeof FinalizationRegistry !== "undefined") {
       this.cleanup = new FinalizationRegistry((dataId: string) => {
-        // When result object is GC'd, tell worker to release its data function
-        if (this.worker) {
+        if (this.useWorker && sharedWorker) {
           try {
-            this.worker.postMessage({
-              id: `cleanup_${Date.now()}`,
-              method: "releaseData",
-              args: [dataId],
-            });
+            sendWorkerMessage(this.instanceId, "releaseData", [dataId]).catch(
+              () => {},
+            );
           } catch (e) {
             // If the worker is dead, that's the ultimate GC :-)
           }
@@ -39,6 +118,7 @@ export class PagefindWrapper {
   }
 
   constructor(options: PagefindIndexOptions = {}) {
+    this.instanceId = generateInstanceId();
     this.basePath = options.basePath || "/pagefind/";
     this.initOptions = options;
 
@@ -64,56 +144,36 @@ export class PagefindWrapper {
 
   private async init() {
     if (hasWorkerSupport && !(this.initOptions as any).noWorker) {
-      try {
-        const workerUrl = `${this.basePath}pagefind-worker.js`;
-        this.worker = new Worker(workerUrl);
+      const workerAvailable = initSharedWorker(this.basePath);
 
-        this.worker.addEventListener("error", (error) => {
+      if (workerAvailable) {
+        try {
+          sharedWorkerRefCount++;
+          this.useWorker = true;
+
+          await Promise.race([
+            sendWorkerMessage(this.instanceId, "init", [this.initOptions]),
+            new Promise((_, reject) =>
+              setTimeout(
+                () => reject(new Error("Worker initialization timeout")),
+                5000,
+              ),
+            ),
+          ]);
+          this.initialized = true;
+        } catch (error) {
           console.warn(
-            "The Pagefind web worker encountered an error, falling back to main thread:",
+            "Failed to initialize Pagefind in the web worker, falling back to main thread:",
             error,
           );
-          this.worker = null;
-
-          // Reject all pending messages
-          const pending = Array.from(this.pendingMessages.values());
-          this.pendingMessages.clear();
-          for (const { reject } of pending) {
-            reject(new Error("Worker failed, falling back to main thread"));
-          }
-
+          // Clean up the possibly-orphaned instance in the worker
+          sendWorkerMessage(this.instanceId, "destroy", []).catch(() => {});
+          this.useWorker = false;
+          sharedWorkerRefCount--;
           this.initFallback();
-        });
-
-        this.worker.addEventListener("message", (event) => {
-          const { id, result, error } = event.data;
-          const pending = this.pendingMessages.get(id);
-          if (pending) {
-            this.pendingMessages.delete(id);
-            if (error) {
-              pending.reject(new Error(error));
-            } else {
-              pending.resolve(result);
-            }
-          }
-        });
-
-        await Promise.race([
-          this.sendMessage("init", [this.initOptions]),
-          new Promise((_, reject) =>
-            setTimeout(
-              () => reject(new Error("Worker initialization timeout")),
-              5000,
-            ),
-          ),
-        ]);
-        this.initialized = true;
-      } catch (error) {
-        console.warn(
-          "Failed to initialize the Pagefind web worker, falling back to main thread:",
-          error,
-        );
-        this.worker = null;
+          this.initialized = true;
+        }
+      } else {
         this.initFallback();
         this.initialized = true;
       }
@@ -121,6 +181,10 @@ export class PagefindWrapper {
       this.initFallback();
       this.initialized = true;
     }
+  }
+
+  waitForInit(): Promise<void> {
+    return this.initPromise ?? Promise.resolve();
   }
 
   private initFallback() {
@@ -158,15 +222,11 @@ export class PagefindWrapper {
       throw new Error(`Method ${method} not found on fallback`);
     }
 
-    if (!this.worker) {
+    if (!this.useWorker || !sharedWorker) {
       throw new Error("Worker not initialized");
     }
 
-    return new Promise((resolve, reject) => {
-      const id = `msg_${this.messageId++}`;
-      this.pendingMessages.set(id, { resolve, reject });
-      this.worker!.postMessage({ id, method, args });
-    });
+    return sendWorkerMessage(this.instanceId, method, args);
   }
 
   async options(options: PagefindIndexOptions) {
@@ -249,18 +309,17 @@ export class PagefindWrapper {
   }
 
   async destroy() {
-    if (this.worker) {
+    if (this.useWorker) {
       try {
-        await this.sendMessage("destroy", []);
+        await sendWorkerMessage(this.instanceId, "destroy", []);
       } catch (e) {
         // May already be dead
       }
-      this.worker.terminate();
-      this.worker = null;
+      this.useWorker = false;
+      releaseSharedWorker();
     }
     if (this.fallback) {
       this.fallback = null;
     }
-    this.pendingMessages.clear();
   }
 }

--- a/pagefind_web_js/types/index.d.ts
+++ b/pagefind_web_js/types/index.d.ts
@@ -369,6 +369,40 @@ declare global {
     length_bonus: number;
   };
 
+  /**
+   * An independent Pagefind instance returned by createInstance().
+   * Each instance has its own configuration and search state.
+   * All instances share a single web worker and WASM module internally.
+   */
+  type PagefindInstance = {
+    /** Update options for this instance */
+    options: (opts: PagefindIndexOptions) => Promise<void>;
+    /** Wait for this instance to finish initializing (WASM load, etc.) */
+    init: () => Promise<void>;
+    /** Destroy this instance and terminate its worker */
+    destroy: () => Promise<void>;
+    /** Merge an additional index into this instance */
+    mergeIndex: (
+      indexPath: string,
+      options: PagefindIndexOptions,
+    ) => Promise<void>;
+    /** Search this instance's index */
+    search: (
+      term: string,
+      options?: PagefindSearchOptions,
+    ) => Promise<PagefindIndexesSearchResults>;
+    /** Debounced search — returns null if superseded by a newer call */
+    debouncedSearch: (
+      term: string,
+      options?: PagefindSearchOptions,
+      debounceTimeoutMs?: number,
+    ) => Promise<PagefindIndexesSearchResults | null>;
+    /** Preload index chunks for a search term without returning results */
+    preload: (term: string, options?: PagefindSearchOptions) => Promise<void>;
+    /** Retrieve all available filter values and counts */
+    filters: () => Promise<PagefindFilterCounts>;
+  };
+
   /** Raw data about elements with IDs that Pagefind encountered when indexing the page */
   type PagefindSearchAnchor = {
     /** What element type was this anchor? e.g. `h1`, `div` */


### PR DESCRIPTION
Well noted in the beta discussion that config would bleed between unique component UI instances on the page. Needed to do a bit of a deeper severance of the Pagefind internals to fix this.