### PR TITLE
Fix relative image URLs breaking in search results

### DIFF
--- a/docs/content/docs/components/results.md
+++ b/docs/content/docs/components/results.md
@@ -82,6 +82,18 @@ Templates receive this data structure:
 
 Each sub-result has: `title`, `url`, `excerpt`.
 
+### Template Filters
+
+The template engine provides [built-in filters](https://github.com/bglw/adequate-little-templates?tab=readme-ov-file#syntax). The Component UI registers the following additional filters:
+
+#### `resolveUrl(pageUrl)`
+
+Resolves a relative URL against a page URL. Absolute URLs are returned unchanged.
+
+```
+"images/hero.png" | resolveUrl("/blog/post/")  →  /blog/post/images/hero.png
+```
+
 ### Placeholder Template
 
 While results are loading, a skeleton placeholder is shown. You can customize it with a second template using `data-template="placeholder"`, as shown in the full example below. The placeholder template receives no data — it is static HTML.
@@ -96,7 +108,7 @@ Here's the built-in template. Copy and customize it:
     <li class="pf-result">
       <div class="pf-result-card">
         {{#if and(options.show_images, meta.image)}}
-        <img class="pf-result-image" src="{{ meta.image }}" alt="{{ meta.image_alt | default(meta.title) }}">
+        <img class="pf-result-image" src="{{ meta.image | resolveUrl(meta.url | default(url)) }}" alt="{{ meta.image_alt | default(meta.title) }}">
         {{/if}}
         <div class="pf-result-content">
           <p class="pf-result-title">

--- a/pagefind/integration_tests/web_components/relative-image-urls.toolproof.yml
+++ b/pagefind/integration_tests/web_components/relative-image-urls.toolproof.yml
@@ -1,0 +1,49 @@
+name: Web Components Tests > Relative image URLs are resolved against the page URL
+steps:
+  - step: I have the environment variable "PAGEFIND_SITE" set to "public"
+  - step: I have a "public/index.html" file with the content {html}
+    html: |-
+      <!DOCTYPE html><html lang="en"><head>
+      <link href="/pagefind/pagefind-component-ui.css" rel="stylesheet">
+      </head><body>
+      <pagefind-config preload></pagefind-config>
+      <pagefind-input></pagefind-input>
+      <pagefind-results show-images></pagefind-results>
+      <script src="/pagefind/pagefind-component-ui.js" type="module"></script>
+      </body></html>
+  - step: I have a "public/blog/post/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html
+      lang="en"><head></head><body><h1>Relative Image</h1><img
+      src="images/header.png"><p>A page with a relative image
+      URL.</p></body></html>
+  - step: I have a "public/about/index.html" file with the content {html}
+    html: >-
+      <!DOCTYPE html><html
+      lang="en"><head></head><body><h1>Absolute Image</h1><img
+      src="/images/hero.png"><p>A page with an absolute image
+      URL.</p></body></html>
+  - macro: I run Pagefind
+  - step: stdout should contain "Running Pagefind"
+  - step: I serve the directory "public"
+  - step: In my browser, I load "/"
+  - step: In my browser, I click the selector "pagefind-input input"
+  - step: In my browser, I type "image"
+  - step: In my browser, the console should be empty
+  - step: In my browser, I evaluate {js}
+    js: |-
+      let results = await toolproof.querySelector("pagefind-results ul");
+      await toolproof.waitFor(() => results.querySelectorAll("li a").length === 2);
+  - snapshot: In my browser, the result of {js}
+    js: |-
+      let results = await toolproof.querySelector("pagefind-results ul");
+      let items = Array.from(results.querySelectorAll("li"));
+      items.sort((a, b) => a.textContent.localeCompare(b.textContent));
+      return items.map(li => {
+        let title = li.querySelector("a").textContent;
+        let img = li.querySelector("img");
+        return title + ": " + (img ? img.getAttribute("src") : "no image");
+      }).join("\n");
+    snapshot_content: |-
+      ╎Absolute Image: /images/hero.png
+      ╎Relative Image: /blog/post/images/header.png

--- a/pagefind_ui/component/components/index.ts
+++ b/pagefind_ui/component/components/index.ts
@@ -1,5 +1,17 @@
 export { getInstanceManager, configureInstance } from "./instance-manager";
 
+import { registerFunction } from "adequate-little-templates";
+
+registerFunction("resolveUrl", (url, pageUrl) => {
+  const s = String(url ?? "");
+  if (!s || /^[a-z][a-z0-9+.-]*:/i.test(s) || /^\/\//.test(s) || s.startsWith("/")) return s;
+  try {
+    return new URL(s, new URL(String(pageUrl ?? "/"), "https://p")).pathname;
+  } catch {
+    return s;
+  }
+});
+
 import "./pagefind-config";
 import "./pagefind-input";
 import "./pagefind-summary";

--- a/pagefind_ui/component/components/pagefind-results.ts
+++ b/pagefind_ui/component/components/pagefind-results.ts
@@ -45,7 +45,7 @@ const templateNodes = (templateResult: TemplateResult): Node[] => {
 const DEFAULT_RESULT_TEMPLATE = `<li class="pf-result">
   <div class="pf-result-card">
     {{#if and(options.show_images, meta.image)}}
-    <img class="pf-result-image" src="{{ meta.image }}" alt="{{ meta.image_alt | default(meta.title) }}">
+    <img class="pf-result-image" src="{{ meta.image | resolveUrl(meta.url | default(url)) }}" alt="{{ meta.image_alt | default(meta.title) }}">
     {{/if}}
     <div class="pf-result-content">
       <p class="pf-result-title">

--- a/pagefind_ui/default/svelte/result.svelte
+++ b/pagefind_ui/default/svelte/result.svelte
@@ -8,9 +8,21 @@
     let data;
     let meta = [];
 
+    const resolveImageUrl = (src, pageUrl) => {
+        if (!src || /^[a-z][a-z0-9+.-]*:/i.test(src) || /^\/\//.test(src) || src.startsWith("/")) return src;
+        try {
+            return new URL(src, new URL(pageUrl || "/", "https://p")).pathname;
+        } catch {
+            return src;
+        }
+    };
+
     const load = async (r) => {
         data = await r.data();
         data = process_result?.(data) ?? data;
+        if (data.meta?.image) {
+            data = { ...data, meta: { ...data.meta, image: resolveImageUrl(data.meta.image, data.meta.url || data.url) } };
+        }
         meta = Object.entries(data.meta).filter(
             ([key]) => !skipMeta.includes(key),
         );


### PR DESCRIPTION
This is handled in the component UI by adding a new template filter and using it in the default result template.