### PR TITLE
wasm-unsafe-eval is supported since Safari 16 released in 2022

### DIFF
--- a/docs/content/docs/hosting.md
+++ b/docs/content/docs/hosting.md
@@ -15,9 +15,7 @@ Pagefind handles compression of the files in the bundle directly, so no server g
 
 If you have a strict content security policy enabled on your site, you may encounter issues with the Pagefind WebAssembly — this isn't specific to Pagefind but is an issue with CSP and WebAssembly.
 
-The most widely-supported solution at the current moment is to ensure your Content Security Policy allows `script-src 'unsafe-eval'`, which will work in all browsers.
-
-A [proposal exists](https://github.com/WebAssembly/content-security-policy/blob/main/proposals/CSP.md) for `script-src 'wasm-unsafe-eval'`, which is supported in Chrome, Firefox, and Edge, but has not yet shipped to a stable Safari version.
+The most widely-supported solution at the current moment is to ensure your Content Security Policy allows `script-src 'wasm-unsafe-eval'`, which is supported in Chrome, Firefox, Edge, and Safari since 2022.
 
 > In the future, hopefully a `wasm-src` attribute / SRI hash validation will be supported in CSP, as proposed in [chrome#961485](https://bugs.chromium.org/p/chromium/issues/detail?id=961485), [chrome#945121](https://bugs.chromium.org/p/chromium/issues/detail?id=945121).
 [Open an issue](https://github.com/pagefind/pagefind/issues) if this is now the case!


### PR DESCRIPTION
See
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/script-src#browser_compatibility