### PR TITLE
Use jemalloc on musl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2167,6 +2167,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha-1",
+ "tikv-jemallocator",
  "tokio",
  "twelf",
  "typed-builder",
@@ -3097,6 +3098,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/pagefind/Cargo.toml
+++ b/pagefind/Cargo.toml
@@ -94,6 +94,9 @@ rayon = "1.10"
 rust-patch = "0.1.3"
 typed-builder = "0.23.2"
 
+[target.'cfg(all(target_env = "musl", target_pointer_width = "64"))'.dependencies]
+tikv-jemallocator = { version = "0.6", features = ["background_threads"] }
+
 [features]
 default = ["serve"]
 extended = ["dep:charabia"]

--- a/pagefind/Cargo.toml
+++ b/pagefind/Cargo.toml
@@ -95,7 +95,7 @@ rust-patch = "0.1.3"
 typed-builder = "0.23.2"
 
 [target.'cfg(all(target_env = "musl", target_pointer_width = "64"))'.dependencies]
-tikv-jemallocator = { version = "0.6", features = ["background_threads"] }
+tikv-jemallocator = "0.6"
 
 [features]
 default = ["serve"]

--- a/pagefind/src/main.rs
+++ b/pagefind/src/main.rs
@@ -1,3 +1,7 @@
+#[cfg(all(target_env = "musl", target_pointer_width = "64"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 use pagefind::runner::run_indexer;
 
 #[tokio::main]


### PR DESCRIPTION
Fixes #1119 by swapping out the garbo default musl allocator which should have been done ages ago.